### PR TITLE
Added Mount & Blade Warband server egg

### DIFF
--- a/mb_warband/egg-m--b-warband.json
+++ b/mb_warband/egg-m--b-warband.json
@@ -1,0 +1,81 @@
+{
+    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
+    "meta": {
+        "version": "PTDL_v1"
+    },
+    "exported_at": "2018-07-28T22:01:58-04:00",
+    "name": "M&B Warband",
+    "author": "mason@rowe.sh",
+    "description": "Mount & Blade Warband server",
+    "image": "masonr\/pterodactyl-images:mb-warband",
+    "startup": "WINEDEBUG=\"fixme-all\" wine mb_warband_dedicated.exe -r Config.txt -m {{MODULE}}",
+    "config": {
+        "files": "{}",
+        "startup": "{\r\n    \"done\": \"Starting mission\",\r\n    \"userInteraction\": []\r\n}",
+        "logs": "{\r\n    \"custom\": false,\r\n    \"location\": \"Logs\/\"\r\n}",
+        "stop": "^C"
+    },
+    "scripts": {
+        "installation": {
+            "script": "#!\/bin\/bash\r\napt update\r\napt install -y wget dos2unix\r\ncd \/mnt\/server\/\r\n\r\nif [[ -z \"$MODULE\" ]] ; then\r\n\tMODULE=\"Native\"\r\nfi\r\n\r\n# Download helper script with all server file links\r\nwget \"https:\/\/files.rowe.sh\/pterodactyl\/mb-warband\/mb-warband-links.sh\"\r\nchmod +x mb-warband-links.sh\r\n\r\n# Generate links for server files\r\nMODULE_BASE_LINK=`.\/mb-warband-links.sh link \"$MODULE\" base`\r\nMODULE_LINK=`.\/mb-warband-links.sh link \"$MODULE\" mod`\r\n\r\n# Ensure module files link has been obtained, exit if not\r\nif [[ -z \"$MODULE_LINK\" ]] ; then\r\n\techo \"ERROR: Module name was mistyped or is not currently supported.\"\r\n\techo \"Available modules:\"\r\n\t.\/mb-warband-links.sh modules\r\n\texit 1\r\nfi\r\n\r\n# Install base server files, if needed\r\nif [[ ! -z \"$MODULE_BASE_LINK\" ]] ; then\r\n\twget -qO- $MODULE_BASE_LINK | tar xvz --strip-components=1\r\nfi\r\n\r\n# Install module files\r\nwget -qO- $MODULE_LINK | tar xvz --strip-components=1\r\ncp -rf \"$MODULE\"_Sample_Config.txt Config.txt\r\ndos2unix Config.txt\r\n\r\necho \"Module: $MODULE has been sucessfully installed.\"\r\nrm mb-warband-links.sh\r\n\r\n# Edit Server Name ($SERVER_NAME)\r\nsed -i 's\/.*set_server_name.*\/set_server_name '\"$SERVER_NAME\"'\/g' Config.txt\r\n\r\n# Edit Server Admin Password ($ADMIN_PASSWORD)\r\nsed -i 's\/.*set_pass_admin.*\/set_pass_admin '\"$ADMIN_PASS\"'\/g' Config.txt\r\n\r\n# Edit Server Password ($SERVER_PASS)\r\nsed -i 's\/.*set_pass .*\/set_pass '\"$SERVER_PASS\"'\/g' Config.txt\r\nsed -i 's\/.*set_pass$\/set_pass '\"$SERVER_PASS\"'\/g' Config.txt\r\n\r\n# Edit Server Welcome Message ($MOTD)\r\nsed -i 's\/.*set_welcome_message.*\/set_welcome_message '\"$MOTD\"'\/g' Config.txt\r\n\r\n# Edit Player Count ($PLAYERS)\r\nsed -i 's\/.*set_max_players.*\/set_max_players '\"$PLAYERS\"' '\"$PLAYERS\"'\/g' Config.txt\r\n\r\n# Edit Server Port ($SERVER_PORT)\r\nsed -i 's\/.*set_port.*\/set_port '\"$SERVER_PORT\"'\/g' Config.txt",
+            "container": "ubuntu:16.04",
+            "entrypoint": "bash"
+        }
+    },
+    "variables": [
+        {
+            "name": "Module",
+            "description": "Name of the module. For a full list of supported modules visit --- https:\/\/github.com\/masonr\/pterodactyl-images\/tree\/mb-warband --- and copy the module name from the first column exactly as shown.",
+            "env_variable": "MODULE",
+            "default_value": "Native",
+            "user_viewable": 1,
+            "user_editable": 1,
+            "rules": "required|string|max:200"
+        },
+        {
+            "name": "Player Count",
+            "description": "Number of players",
+            "env_variable": "PLAYERS",
+            "default_value": "32",
+            "user_viewable": 1,
+            "user_editable": 0,
+            "rules": "required|integer|max:200"
+        },
+        {
+            "name": "Server Name",
+            "description": "Name of the game server",
+            "env_variable": "SERVER_NAME",
+            "default_value": "Pterodactyl_Server",
+            "user_viewable": 1,
+            "user_editable": 1,
+            "rules": "required|string|max:100"
+        },
+        {
+            "name": "Admin Password",
+            "description": "Password for admin login",
+            "env_variable": "ADMIN_PASS",
+            "default_value": "ptero",
+            "user_viewable": 1,
+            "user_editable": 1,
+            "rules": "required|string|max:50"
+        },
+        {
+            "name": "Welcome Message",
+            "description": "Welcome message \/ MOTD",
+            "env_variable": "MOTD",
+            "default_value": "Welcome!",
+            "user_viewable": 1,
+            "user_editable": 1,
+            "rules": "required|string|max:500"
+        },
+        {
+            "name": "Server Password",
+            "description": "Password for the server.\r\nLeave blank to keep server unlocked.",
+            "env_variable": "SERVER_PASS",
+            "default_value": "",
+            "user_viewable": 1,
+            "user_editable": 1,
+            "rules": "nullable|string|max:50"
+        }
+    ]
+}


### PR DESCRIPTION
This is an egg to run Mount and Blade Warband game servers. Currently support 15 modules, each individually tested. This egg did need a new image (uses wine) and a custom install/start script to download and set up the various server files needed for the module being run. It also supports changing the Warband module on-the-fly and will backup the old config/logs, download the new module's server files, and create the new startup config.

Complete code for the egg and the required Docker image can be found here:
https://github.com/masonr/pterodactyl-images/tree/mb-warband