### PR TITLE
Change Unturned to use GitLab registry

### DIFF
--- a/unturned/rocketmod/egg-rocketmod.json
+++ b/unturned/rocketmod/egg-rocketmod.json
@@ -7,7 +7,7 @@
     "name": "RocketMod",
     "author": "isaac@isaacs.site",
     "description": "The RocketMod server mod for Unturned.",
-    "image": "tenten8401\/pterodactyl-unturned",
+    "image": "registry.gitlab.com\/tenten8401\/pterodactyl-unturned",
     "startup": "mono RocketLauncher.exe unturned",
     "config": {
         "files": "{\r\n     \"Servers\/unturned\/Server\/Commands.dat\": {\r\n    \"parser\": \"file\",\r\n    \"find\": {\r\n    \"Port\": \"Port {{server.build.default.port}}\"\r\n    }\r\n}\r\n}",


### PR DESCRIPTION
Moving the egg to GitLab from Docker Hub because the builds are much faster and it's integrated with the project.

https://gitlab.com/tenten8401/pterodactyl-unturned/container_registry