### PR TITLE
Added steam auth for rocketmod

### DIFF
--- a/unturned/rocketmod/egg-rocketmod.json
+++ b/unturned/rocketmod/egg-rocketmod.json
@@ -17,29 +17,38 @@
     },
     "scripts": {
         "installation": {
-            "script": "apt update\r\napt -y --no-install-recommends install curl lib32gcc1 ca-certificates\r\n\r\ncd \/tmp\r\ncurl -sSL -o steamcmd.tar.gz http:\/\/media.steampowered.com\/installer\/steamcmd_linux.tar.gz\r\n\r\nmkdir -p \/mnt\/server\/steam\r\ntar -xzvf steamcmd.tar.gz -C \/mnt\/server\/steam\r\ncd \/mnt\/server\/steam\r\n\r\nchown -R root:root \/mnt\r\n\r\nexport HOME=\/mnt\/server\r\n.\/steamcmd.sh +@sSteamCmdForcePlatformBitness 32 +login \"${STEAM_USER}\" \"${STEAM_PASS}\" +force_install_dir \/mnt\/server +app_update 304930 +quit\r\n\r\nmkdir -p \/mnt\/server\/Servers\/unturned\/Server\r\necho \"Port 27015\" > \/mnt\/server\/Servers\/unturned\/Server\/Commands.dat\r\n\r\nmkdir -p \/mnt\/server\/.steam\/sdk32\r\ncp -v linux32\/steamclient.so ..\/.steam\/sdk32\/steamclient.so",
+            "script": "apt update\r\napt -y --no-install-recommends install curl lib32gcc1 ca-certificates\r\n\r\ncd \/tmp\r\ncurl -sSL -o steamcmd.tar.gz http:\/\/media.steampowered.com\/installer\/steamcmd_linux.tar.gz\r\n\r\nmkdir -p \/mnt\/server\/steam\r\ntar -xzvf steamcmd.tar.gz -C \/mnt\/server\/steam\r\ncd \/mnt\/server\/steam\r\n\r\nchown -R root:root \/mnt\r\n\r\nexport HOME=\/mnt\/server\r\n.\/steamcmd.sh +@sSteamCmdForcePlatformBitness 32 +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} +force_install_dir \/mnt\/server +app_update 304930 +quit\r\n\r\nmkdir -p \/mnt\/server\/Servers\/unturned\/Server\r\necho \"Port 27015\" > \/mnt\/server\/Servers\/unturned\/Server\/Commands.dat\r\n\r\nmkdir -p \/mnt\/server\/.steam\/sdk32\r\ncp -v linux32\/steamclient.so ..\/.steam\/sdk32\/steamclient.so",
             "container": "ubuntu:16.04",
             "entrypoint": "bash"
         }
     },
     "variables": [
         {
-            "name": "Account Name",
-            "description": "A Steam username w\/ Unturned on the account.",
+            "name": "Steam User",
+            "description": "A Steam username with Unturned on the account.",
             "env_variable": "STEAM_USER",
-            "default_value": "",
+            "default_value": "anonymous",
             "user_viewable": 0,
             "user_editable": 0,
-            "rules": "required"
+            "rules": "required|string"
         },
         {
-            "name": "Account Password",
-            "description": "The password for the Steam account.",
+            "name": "Steam Password",
+            "description": "Steam User Password",
             "env_variable": "STEAM_PASS",
             "default_value": "",
             "user_viewable": 0,
             "user_editable": 0,
-            "rules": "required"
+            "rules": "nullable|string"
+        },
+        {
+            "name": "Steam Auth Code",
+            "description": "Steam Auth Code only when you're using Steam Auth",
+            "env_variable": "STEAM_AUTH",
+            "default_value": "",
+            "user_viewable": 0,
+            "user_editable": 0,
+            "rules": "nullable|string"
         }
     ]
 }


### PR DESCRIPTION
- It only works with the Mobile Auth App.
- When your not using any auth let it empty.
- The reason is that the Email Auth sends you the code when you're trying to login but you'll need to enter the key bevor that.