### PR TITLE
Added steam auth for arma3

### DIFF
--- a/arma/arma3/egg-arma3.json
+++ b/arma/arma3/egg-arma3.json
@@ -3,7 +3,7 @@
     "meta": {
         "version": "PTDL_v1"
     },
-    "exported_at": "2019-01-08T20:30:59-05:00",
+    "exported_at": "2018-10-16T13:07:23-04:00",
     "name": "Arma 3",
     "author": "daave@aaathats3as.com",
     "description": "Experience true combat gameplay in a massive military sandbox. Deploying a wide variety of single- and multiplayer content, over 20 vehicles and 40 weapons, and limitless opportunities for content creation, this is the PC's premier military game. Authentic, diverse, open - Arma 3 sends you to war.",
@@ -17,7 +17,7 @@
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/bash\r\n\r\napt -y update\r\napt -y --no-install-recommends install curl\r\napt -y --no-install-recommends install lib32gcc1 ca-certificates\r\n\r\ncd \/tmp\r\ncurl -sSLO http:\/\/media.steampowered.com\/installer\/steamcmd_linux.tar.gz\r\n\r\nmkdir -p \/mnt\/server\/steamcmd \/mnt\/server\/logs\r\nmkdir -p \"\/mnt\/server\/.local\/share\/Arma 3\" \"\/mnt\/server\/.local\/share\/Arma 3 - Other Profiles\"\r\n\r\ntouch \/mnt\/server\/latest.log\r\nchown -R root:root \/mnt\r\n\r\ntar -xzvf \/tmp\/steamcmd_linux.tar.gz -C \/mnt\/server\/steamcmd\r\ncd \/mnt\/server\/steamcmd\r\nexport HOME=\/mnt\/server\r\n\r\n.\/steamcmd.sh +login ${STEAM_USER} ${STEAM_PASS} +force_install_dir \/mnt\/server +app_update ${APP_ID} validate +quit",
+            "script": "#!\/bin\/bash\r\n\r\napt -y update\r\napt -y --no-install-recommends install curl\r\napt -y --no-install-recommends install lib32gcc1 ca-certificates\r\n\r\ncd \/tmp\r\ncurl -sSLO http:\/\/media.steampowered.com\/installer\/steamcmd_linux.tar.gz\r\n\r\nmkdir -p \/mnt\/server\/steamcmd \/mnt\/server\/logs\r\nmkdir -p \"\/mnt\/server\/.local\/share\/Arma 3\" \"\/mnt\/server\/.local\/share\/Arma 3 - Other Profiles\"\r\n\r\ntouch \/mnt\/server\/latest.log\r\nchown -R root:root \/mnt\r\n\r\ntar -xzvf \/tmp\/steamcmd_linux.tar.gz -C \/mnt\/server\/steamcmd\r\ncd \/mnt\/server\/steamcmd\r\nexport HOME=\/mnt\/server\r\n\r\n.\/steamcmd.sh +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} +force_install_dir \/mnt\/server +app_update ${APP_ID} validate +quit",
             "container": "ubuntu:18.04",
             "entrypoint": "bash"
         }
@@ -79,21 +79,30 @@
         },
         {
             "name": "Steam User",
-            "description": "Admin only",
+            "description": "A Steam username with Arma3 on the account.",
             "env_variable": "STEAM_USER",
-            "default_value": "",
+            "default_value": "anonymous",
             "user_viewable": 0,
             "user_editable": 0,
             "rules": "required|string"
         },
         {
-            "name": "STEAM_PASS",
-            "description": "STEAM_PASS",
+            "name": "Steam Password",
+            "description": "Steam User Password",
             "env_variable": "STEAM_PASS",
             "default_value": "",
             "user_viewable": 0,
             "user_editable": 0,
-            "rules": "required|string"
+            "rules": "nullable|string"
+        },
+        {
+            "name": "Steam Auth Code",
+            "description": "Steam Auth Code only when you're using Steam Auth",
+            "env_variable": "STEAM_AUTH",
+            "default_value": "",
+            "user_viewable": 0,
+            "user_editable": 0,
+            "rules": "nullable|string"
         }
     ]
 }


### PR DESCRIPTION
- It only works with the Mobile Auth App.
- When your not using any auth let it empty.
- The reason is that the Email Auth sends you the code when you're trying to login but you'll need to enter the key bevor that.