### PR TITLE
Change FiveM Max Players

### DIFF
--- a/gta/fivem/egg-five-m.json
+++ b/gta/fivem/egg-five-m.json
@@ -36,10 +36,10 @@
             "name": "Max Players",
             "description": "Set the fivem max play count",
             "env_variable": "MAX_PLAYERS",
-            "default_value": "30",
+            "default_value": "32",
             "user_viewable": 1,
             "user_editable": 0,
-            "rules": "required|integer|between:1,31"
+            "rules": "required|integer|between:1,32"
         },
         {
             "name": "Server Hostname",


### PR DESCRIPTION
FiveM can accept up to 32 players (64 if you're using OneSync)

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to an existing Egg:

1. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [x] Have you tested your Egg changes?