### PR TITLE
Update RocketMod egg to use Dedicated Unturned server

### DIFF
--- a/unturned/rocketmod/egg-rocketmod.json
+++ b/unturned/rocketmod/egg-rocketmod.json
@@ -17,38 +17,9 @@
     },
     "scripts": {
         "installation": {
-            "script": "apt update\r\napt -y --no-install-recommends install curl lib32gcc1 ca-certificates\r\n\r\ncd \/tmp\r\ncurl -sSL -o steamcmd.tar.gz http:\/\/media.steampowered.com\/installer\/steamcmd_linux.tar.gz\r\n\r\nmkdir -p \/mnt\/server\/steam\r\ntar -xzvf steamcmd.tar.gz -C \/mnt\/server\/steam\r\ncd \/mnt\/server\/steam\r\n\r\nchown -R root:root \/mnt\r\n\r\nexport HOME=\/mnt\/server\r\n.\/steamcmd.sh +@sSteamCmdForcePlatformBitness 32 +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} +force_install_dir \/mnt\/server +app_update 304930 +quit\r\n\r\nmkdir -p \/mnt\/server\/Servers\/unturned\/Server\r\necho \"Port 27015\" > \/mnt\/server\/Servers\/unturned\/Server\/Commands.dat\r\n\r\nmkdir -p \/mnt\/server\/.steam\/sdk32\r\ncp -v linux32\/steamclient.so ..\/.steam\/sdk32\/steamclient.so",
+            "script": "apt update\r\napt -y --no-install-recommends install curl lib32gcc1 ca-certificates\r\n\r\ncd \/tmp\r\ncurl -sSL -o steamcmd.tar.gz http:\/\/media.steampowered.com\/installer\/steamcmd_linux.tar.gz\r\n\r\nmkdir -p \/mnt\/server\/steam\r\ntar -xzvf steamcmd.tar.gz -C \/mnt\/server\/steam\r\ncd \/mnt\/server\/steam\r\n\r\nchown -R root:root \/mnt\r\n\r\nexport HOME=\/mnt\/server\r\n.\/steamcmd.sh +login anonymous +force_install_dir \/mnt\/server +app_update 1110390 +quit\r\n\r\nmkdir -p \/mnt\/server\/Servers\/unturned\/Server\r\necho \"Port 27015\" > \/mnt\/server\/Servers\/unturned\/Server\/Commands.dat",
             "container": "ubuntu:16.04",
             "entrypoint": "bash"
         }
-    },
-    "variables": [
-        {
-            "name": "Steam User",
-            "description": "A Steam username with Unturned on the account.",
-            "env_variable": "STEAM_USER",
-            "default_value": "anonymous",
-            "user_viewable": 0,
-            "user_editable": 0,
-            "rules": "required|string"
-        },
-        {
-            "name": "Steam Password",
-            "description": "Steam User Password",
-            "env_variable": "STEAM_PASS",
-            "default_value": "",
-            "user_viewable": 0,
-            "user_editable": 0,
-            "rules": "nullable|string"
-        },
-        {
-            "name": "Steam Auth Code",
-            "description": "Steam Auth Code only when you're using Steam Auth",
-            "env_variable": "STEAM_AUTH",
-            "default_value": "",
-            "user_viewable": 0,
-            "user_editable": 0,
-            "rules": "nullable|string"
-        }
-    ]
+    }
 }


### PR DESCRIPTION
Using dedicated Unturned server now. The dedicated server runs in 64bit mode and is about half the size of the full game. This saves disk space and bandwidth.

Related PSA
https://github.com/SmartlyDressedGames/Unturned-3.x-Community/issues/855

Fixes #172 