### PR TITLE
Update Unturned Egg to use Dedicated Server, Supersedes #248

### DIFF
--- a/unturned/rocketmod/egg-rocket-mod-modern.json
+++ b/unturned/rocketmod/egg-rocket-mod-modern.json
@@ -1,0 +1,26 @@
+{
+    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
+    "meta": {
+        "version": "PTDL_v1"
+    },
+    "exported_at": "2019-07-14T14:37:31+00:00",
+    "name": "RocketMod Modern",
+    "author": "isaac@isaacs.site",
+    "description": "The RocketMod server mod for Unturned.",
+    "image": "registry.gitlab.com\/tenten8401\/pterodactyl-unturned:modern",
+    "startup": "mono RocketLauncher.exe unturned",
+    "config": {
+        "files": "{\r\n    \"Servers\/unturned\/Server\/Commands.dat\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"Port\": \"Port {{server.build.default.port}}\"\r\n        }\r\n    }\r\n}",
+        "startup": "{\r\n    \"done\": \"Loading level: 100%\",\r\n    \"userInteraction\": []\r\n}",
+        "logs": "{\r\n    \"custom\": true,\r\n    \"location\": \"latest.log\"\r\n}",
+        "stop": "shutdown"
+    },
+    "scripts": {
+        "installation": {
+            "script": "apt update\r\napt -y --no-install-recommends install curl lib32gcc1 ca-certificates telnet ssh xvfb\r\n\r\ncd \/tmp\r\ncurl -sSL -o steamcmd.tar.gz https:\/\/steamcdn-a.akamaihd.net\/client\/installer\/steamcmd_linux.tar.gz\r\n\r\nmkdir -p \/mnt\/server\/steam\r\ntar -xzvf steamcmd.tar.gz -C \/mnt\/server\/steam\r\ncd \/mnt\/server\/steam\r\n\r\nchown -R root:root \/mnt\r\n.\/steamcmd.sh  +@sSteamCmdForcePlatformBitness 64 +login anonymous +app_update 1110390 +force_install_dir \/mnt\/server +quit\r\n\r\nmkdir -p \/mnt\/server\/Servers\/unturned\/Server\r\necho \"Port 27015\" > \/mnt\/server\/Servers\/unturned\/Server\/Commands.dat\r\n\r\nmkdir -p \/mnt\/server\/.steam\/sdk32\r\ncp -v linux32\/steamclient.so ..\/.steam\/sdk32\/steamclient.so",
+            "container": "ubuntu:18.04",
+            "entrypoint": "bash"
+        }
+    },
+    "variables": []
+}

--- a/unturned/rocketmod/egg-rocketmod-old.json
+++ b/unturned/rocketmod/egg-rocketmod-old.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v1"
     },
     "exported_at": "2018-04-27T21:30:05+00:00",
-    "name": "RocketMod",
+    "name": "RocketMod Old",
     "author": "isaac@isaacs.site",
     "description": "The RocketMod server mod for Unturned.",
     "image": "registry.gitlab.com\/tenten8401\/pterodactyl-unturned",


### PR DESCRIPTION
I've updated the Unturned egg to use the new dedicated server, like mentioned in #248. My change renames the old egg since I can't get it to start when used on an old server, adds a new egg named "modern", and updates the container to use the new the new modern branch from my GitLab registry. Tested on my personal server and I can start it, connect & play just fine.
![Image](https://media.discordapp.net/attachments/272491659810570240/599961431173103656/unknown.png)

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [ ] Did you branch your changes and PR from that branch and not from your master branch?

### Changes to an existing Egg:

1. [X] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [X] Have you tested your Egg changes?