### PR TITLE
Workaround for bugged console output

### DIFF
--- a/minecraft_java/paper/egg-paper.json
+++ b/minecraft_java/paper/egg-paper.json
@@ -8,7 +8,7 @@
     "author": "parker@pterodactyl.io",
     "description": "High performance Spigot fork that aims to fix gameplay and mechanics inconsistencies.",
     "image": "quay.io\/parkervcp\/pterodactyl-images:debian_openjdk-8-jre",
-    "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",
+    "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",
     "config": {
         "files": "{\r\n    \"server.properties\": {\r\n        \"parser\": \"properties\",\r\n        \"find\": {\r\n            \"server-ip\": \"0.0.0.0\",\r\n            \"server-port\": \"{{server.build.default.port}}\",\r\n            \"query.port\": \"{{server.build.default.port}}\"\r\n        }\r\n    }\r\n}",
         "startup": "{\r\n    \"done\": \")! For help, type \",\r\n    \"userInteraction\": [\r\n        \"Go to eula.txt for more info.\"\r\n    ]\r\n}",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

## Explanation
A recent Paper 1.14.4 build changes some console stuff, https://github.com/PaperMC/Paper/commit/fa8b4994ac00ad60298d727feffe607398b1a081

Problem is that Pterodactyl has issues when parsing the console now, this is how the console looks like when you run the latest Paper build:
![image](https://user-images.githubusercontent.com/28601081/61776538-8cac2800-adfb-11e9-8512-6f87c1441508.png)

>... gets added on every line.

![image](https://user-images.githubusercontent.com/28601081/61776569-9766bd00-adfb-11e9-9e85-38cec6c31bd4.png)

This is what's shown when you're trying to enter a command, it doesn't show the command it self, only some weird unicode character and >... >...

 Adding -Dterminal.jline=false -Dterminal.ansi=true to the startup arguments seems to be a workaround for these issues and returns the console back to normal. I've tested this on 1.14.4 and 1.8.8 (1.8.8 is not affected by the Paper PR but I've tested it anyway in case the arguments made the server not start up)

1. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [x] Have you tested your Egg changes?