### PR TITLE
TS3: Add FileTransfer Port Commandline Option

### DIFF
--- a/stock-eggs/voice-servers/egg-teamspeak3-server.json
+++ b/stock-eggs/voice-servers/egg-teamspeak3-server.json
@@ -3,12 +3,12 @@
     "meta": {
         "version": "PTDL_v1"
     },
-    "exported_at": "2019-05-01T16:35:15+00:00",
+    "exported_at": "2019-07-27T21:26:08+02:00",
     "name": "Teamspeak3 Server",
     "author": "support@pterodactyl.io",
     "description": "VoIP software designed with security in mind, featuring crystal clear voice quality, endless customization options, and scalabilty up to thousands of simultaneous users.",
     "image": "quay.io\/pterodactyl\/core:glibc",
-    "startup": ".\/ts3server_minimal_runscript.sh default_voice_port={{SERVER_PORT}} query_port={{SERVER_PORT}}  license_accepted=1",
+    "startup": ".\/ts3server_minimal_runscript.sh default_voice_port={{SERVER_PORT}} query_port={{SERVER_PORT}} filetransfer_port={{FILETRANSFER_PORT}} filetransfer_ip=0.0.0.0 license_accepted=1",
     "config": {
         "files": "{}",
         "startup": "{\"done\": \"listening on 0.0.0.0:\", \"userInteraction\": []}",
@@ -31,6 +31,15 @@
             "user_viewable": 1,
             "user_editable": 1,
             "rules": "required|regex:\/^([0-9_\\.-]{5,10})$\/"
+        },
+        {
+            "name": "FileTransfer-Port",
+            "description": "",
+            "env_variable": "FILETRANSFER_PORT",
+            "default_value": "30033",
+            "user_viewable": 1,
+            "user_editable": 1,
+            "rules": "required|numeric|digits_between:1,5"
         }
     ]
 }


### PR DESCRIPTION
Adds Commandline Option for FileTransfer Port

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Did you branch your changes and PR from that branch and not from your master branch?

### Changes to an existing Egg:

1. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [x] Have you tested your Egg changes?

---------------------------------------------------
Explanation for (changes->1):
The Default Egg does not allow File-Transfers, wich also does'nt allow uploading icons for groups/channels/etc.  
Since that is important to most Ts3 Admins i included the Option to change the Port from the default