### PR TITLE
Update FiveM install script

### DIFF
--- a/gta/fivem/egg-five-m.json
+++ b/gta/fivem/egg-five-m.json
@@ -3,11 +3,11 @@
     "meta": {
         "version": "PTDL_v1"
     },
-    "exported_at": "2019-09-11T10:35:51-04:00",
+    "exported_at": "2019-09-30T21:32:14-04:00",
     "name": "FiveM",
     "author": "parker@parkervcp.com",
     "description": "A new FiveM egg for the latest builds due to recent changes in FiveM",
-    "image": "quay.io\/parkervcp\/pterodactyl-images:alpine",
+    "image": "quay.io\/parkervcp\/pterodactyl-images:base_alpine",
     "startup": "$(pwd)\/alpine\/opt\/cfx-server\/ld-musl-x86_64.so.1 --library-path \"$(pwd)\/alpine\/usr\/lib\/v8\/:$(pwd)\/alpine\/lib\/:$(pwd)\/alpine\/usr\/lib\/\" -- $(pwd)\/alpine\/opt\/cfx-server\/FXServer +set citizen_dir $(pwd)\/alpine\/opt\/cfx-server\/citizen\/ +set sv_licenseKey {{FIVEM_LICENSE}} +set sv_maxplayers {{MAX_PLAYERS}} +exec server.cfg",
     "config": {
         "files": "{\r\n    \"server.cfg\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"endpoint_add_tcp\": \"endpoint_add_tcp \\\"0.0.0.0:{{server.build.default.port}}\\\"\",\r\n            \"endpoint_add_udp\": \"endpoint_add_udp \\\"0.0.0.0:{{server.build.default.port}}\\\"\",\r\n            \"sv_hostname\": \"sv_hostname \\\"{{server.build.env.SERVER_HOSTNAME}}\\\"\",\r\n            \"sv_maxclients\": \"sv_maxclients {{server.build.env.MAX_PLAYERS}}\"\r\n        }\r\n    }\r\n}",
@@ -17,7 +17,7 @@
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/ash \r\n\r\napk add openssl tar xz curl wget git --no-cache\r\n\r\ncd \/mnt\/server\r\n\r\nmkdir resources\r\n\r\necho \"updating citizenfx resource files\"\r\ngit clone https:\/\/github.com\/citizenfx\/cfx-server-data.git \/tmp\r\ncp -Rf \/tmp\/resources\/* resources\/ \r\n\r\ncd \/mnt\/server\r\n\r\necho -e \"pulling files from ${DOWNLOAD_URL}\"\r\nwget ${DOWNLOAD_URL}\r\n\r\necho \"Extracting fivem files\"\r\n\r\ntar xf fx.tar.xz\r\n\r\nrm -rf fx.tar.xz run.sh\r\n\r\nif [ -e server.cfg ]; then\r\n    echo \"server config file exists\"\r\nelse\r\n    echo \"Downloading default fivem config\"\r\n    curl https:\/\/raw.githubusercontent.com\/parkervcp\/eggs\/master\/gta\/fivem\/server.cfg >> server.cfg\r\nfi\r\n\r\nmkdir logs\/\r\n\r\necho \"install complete\"",
+            "script": "#!\/bin\/ash \r\n\r\napk add openssl tar xz curl wget git --no-cache\r\n\r\ncd \/mnt\/server\r\n\r\nmkdir resources\r\n\r\necho \"updating citizenfx resource files\"\r\ngit clone https:\/\/github.com\/citizenfx\/cfx-server-data.git \/tmp\r\ncp -Rf \/tmp\/resources\/* resources\/ \r\n\r\ncd \/mnt\/server\r\n\r\necho \"Downloading the latest fivem server files\"\r\nlatest_fivem_url=`curl https:\/\/runtime.fivem.net\/artifacts\/fivem\/build_proot_linux\/master\/ | grep -Eo 'href=\".*\/\"' | grep -Eo '\".*\"' | grep -Eo 'href=\".*\/\"' | grep -Eo '\".*\"' | sed 's\/\\\"\/\/g'`\r\n\r\necho -e \"pulling files from https:\/\/runtime.fivem.net\/artifacts\/fivem\/build_proot_linux\/master\/${latest_fivem_url}fx.tar.xz\"\r\nwget https:\/\/runtime.fivem.net\/artifacts\/fivem\/build_proot_linux\/master\/${latest_fivem_url}fx.tar.xz\r\n\r\necho \"Extracting fivem files\"\r\n\r\ntar xf fx.tar.xz\r\n\r\nrm -rf fx.tar.xz run.sh\r\n\r\nif [ -e server.cfg ]; then\r\n    echo \"server config file exists\"\r\nelse\r\n    echo \"Downloading default fivem config\"\r\n    curl https:\/\/raw.githubusercontent.com\/parkervcp\/eggs\/master\/gta\/fivem\/server.cfg >> server.cfg\r\nfi\r\n\r\nmkdir logs\/\r\n\r\necho \"install complete\"",
             "container": "alpine:3.10",
             "entrypoint": "ash"
         }
@@ -54,14 +54,14 @@
             "name": "fivem version",
             "description": "The fivem version that is to be installed.\r\n\r\nan example is `1383-e5ea040353ce1b8bc86e37982bf5d888938e3096`\r\n\r\nYou can the latest version from here - https:\/\/runtime.fivem.net\/artifacts\/fivem\/build_proot_linux\/master\/",
             "env_variable": "FIVEM_VERSION",
-            "default_value": "",
+            "default_value": "latest",
             "user_viewable": 1,
-            "user_editable": 0,
+            "user_editable": 1,
             "rules": "required|string|max:50"
         },
         {
             "name": "Download Link",
-            "description": "This is the link to download fivem from.\r\n\r\nThis is only used in the install script.",
+            "description": "This is the link to download fivem from. This is only used in the install script.\r\n\r\nThe file you link to needs to be an fx.tar.zx file.\r\n\r\nExample:\r\nhttps:\/\/runtime.fivem.net\/artifacts\/fivem\/build_proot_linux\/master\/1626-8c06e8bc3ed7e6690c6c2d9e0b90e29df65b3ea6\/fx.tar.xz",
             "env_variable": "DOWNLOAD_URL",
             "default_value": "",
             "user_viewable": 0,

--- a/gta/fivem/egg-five-m.json
+++ b/gta/fivem/egg-five-m.json
@@ -3,7 +3,7 @@
     "meta": {
         "version": "PTDL_v1"
     },
-    "exported_at": "2019-09-30T21:32:14-04:00",
+    "exported_at": "2019-10-04T16:30:46-04:00",
     "name": "FiveM",
     "author": "parker@parkervcp.com",
     "description": "A new FiveM egg for the latest builds due to recent changes in FiveM",
@@ -66,7 +66,7 @@
             "default_value": "",
             "user_viewable": 0,
             "user_editable": 0,
-            "rules": "required|string"
+            "rules": "string|nullable"
         }
     ]
 }


### PR DESCRIPTION
This moves to pulling the latest version for FiveM again.

If they enable buttflare protection it will break but it has support for download URL.

DOWNLOAD_URL is still limited to fx.tar.xz being the filename.

The installer will fail if the file is not named correctly or is the wrong file type.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
### Changes to an existing Egg:

1. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [x] Have you tested your Egg changes?