### PR TITLE
Add Lavalink

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ If you are reading this it looks like you are looking to add an egg to your serv
 * [jmusicbot](/bots/discord/jmusicbot) Java
 * [parkertron](/bots/discord/parkertron/) Golang  
 * [pixel-bot](/bots/discord/pixelbot/) Python  
-* [Sinusbot](/bots/discord/sinusbot/)  
+* [Sinusbot](/bots/discord/sinusbot/)
+* [Lavalink](/bots/discord/lavalink/)
 
 [TeamSpeak3](bots/teamspeak3)
 * [JTS3ServerMod](/bots/teamspeak3/jts3servermod/)

--- a/bots/discord/README.md
+++ b/bots/discord/README.md
@@ -38,3 +38,7 @@ Was used to test python services.
 #### SinusBot
 [SinusBot](https://www.sinusbot.com/)  
 Please Check their site for an in depth on the bot.
+
+#### Lavalink Server
+[Lavalink]()
+Standalone audio sending node based on Lavaplayer and JDA-Audio. Allows for sending audio without it ever reaching any of your shards. Used by many JDA Bots.

--- a/bots/discord/lavalink/README.md
+++ b/bots/discord/lavalink/README.md
@@ -1,0 +1,14 @@
+# Lavalink
+### [Github Resource](https://github.com/Frederikam/Lavalink)
+Standalone audio sending node based on Lavaplayer and JDA-Audio. Allows for sending audio without it ever reaching any of your shards.
+
+Being used in production by FredBoat, Dyno, Rythm, LewdBot, and more.
+
+### Minimum RAM Warning
+
+You need atleast 512 MB of RAM to run 2 audio streams.
+
+### Server Ports
+One port is required. The config will be updated according to the request allocation.
+
+Default Port is 2333.

--- a/bots/discord/lavalink/egg-fredboat-lavalink.json
+++ b/bots/discord/lavalink/egg-fredboat-lavalink.json
@@ -1,0 +1,45 @@
+{
+    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
+    "meta": {
+        "version": "PTDL_v1"
+    },
+    "exported_at": "2019-10-03T10:52:58-07:00",
+    "name": "Fredboat\/Lavalink",
+    "author": "kashalldev@gmail.com",
+    "description": "Standalone audio sending node based on Lavaplayer and JDA-Audio. Allows for sending audio without it ever reaching any of your shards.\r\n\r\nBeing used in production by FredBoat, Dyno, Rythm, LewdBot, and more.\r\n\r\nPowered by Lavaplayer, Minimal CPU\/memory footprint, Twitch\/YouTube stream support, Event system, Seeking, Volume control, REST API for resolving lavaplayer tracks (used for non-JVM clients), Statistics (good for load balancing), Basic authentication, Prometheus metrics.\r\n\r\nhttps:\/\/github.com\/Frederikam\/Lavalink",
+    "image": "quay.io\/parkervcp\/pterodactyl-images:debian_openjdk-8-jre",
+    "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",
+    "config": {
+        "files": "{\r\n    \"application.yml\": {\r\n        \"parser\": \"yaml\",\r\n        \"find\": {\r\n            \"server.port\": \"{{server.build.default.port}}\"\r\n        }\r\n    }\r\n}",
+        "startup": "{\r\n    \"done\": \"Started Launcher\",\r\n    \"userInteraction\": []\r\n}",
+        "logs": "{}",
+        "stop": "^C"
+    },
+    "scripts": {
+        "installation": {
+            "script": "#!\/bin\/ash\r\n# Lavalink Installation Script\r\n#\r\n# Server Files : \/mnt\/server\r\napk update\r\napk add curl\r\ncd \/mnt\/server\r\ncurl -sSL https:\/\/ci.fredboat.com\/repository\/download\/Lavalink_Build\/7107:id\/Lavalink.jar?guest=1 -o ${SERVER_JARFILE}\r\ncurl -sSL https:\/\/raw.githubusercontent.com\/Frederikam\/Lavalink\/master\/LavalinkServer\/application.yml.example -o application.yml",
+            "container": "alpine:3.4",
+            "entrypoint": "ash"
+        }
+    },
+    "variables": [
+        {
+            "name": "Password",
+            "description": "The password the lavalink server should use for authentication.",
+            "env_variable": "password",
+            "default_value": "youshallnotpass",
+            "user_viewable": 1,
+            "user_editable": 1,
+            "rules": "required|string|max:20"
+        },
+        {
+            "name": "Server Jar File",
+            "description": "The name of the server jarfile to run the server with.",
+            "env_variable": "SERVER_JARFILE",
+            "default_value": "Lavalink.jar",
+            "user_viewable": 1,
+            "user_editable": 0,
+            "rules": "required|regex:\/^([\\w\\d._-]+)(\\.jar)$\/"
+        }
+    ]
+}


### PR DESCRIPTION
Downloads Latest Stable Build 7107

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Server Submissions:

1. [X] Does your submission pass tests (server is connectable)?
2. [ ] Does your server use a custom docker image?
    * [X] Have you tried to use a generic image?
    * [ ] Did you PR the necessary changes to make it work?

This build requireds the `quay.io/parkervcp/pterodactyl-images:debian_openjdk-8-jre` docker image.

3. [X] Have you added the server to the main README.md?
4. [X] Have you added a unique README.md for the server you are adding?

I understand as this might be a useless addition but it allows some of the bots that self host but require a Lavalink server to be hosted here as well.