### PR TITLE
Added LD_birary_path to startup command so the new alpha 18 build doe…

### DIFF
--- a/steamcmd_servers/7_days_to_die/egg-7-days-to-die.json
+++ b/steamcmd_servers/7_days_to_die/egg-7-days-to-die.json
@@ -8,7 +8,7 @@
     "author": "kristoffer.norman@bahnhof.se",
     "description": "7 days to die server",
     "image": "quay.io\/parkervcp\/pterodactyl-images:ubuntu_source",
-    "startup": "'.\/7DaysToDieServer.x86_64 -configfile=serverconfig.xml -quit -batchmode -nographics -dedicated -ServerPort=$SERVER_PORT -ServerMaxPlayerCount=$MAX_PLAYERS -GameDifficulty=$GAME_DIFFICULTY -ControlPanelEnabled=false -TelnetEnabled=true -TelnetPort=8081 -logfile logs\/latest.log & echo -e \"Checing on telnet connection\" && until nc -z -v -w5 127.0.0.1 8081; do echo \"Waiting for telnet connection...\"; sleep 5; done && telnet -E 127.0.0.1 8081'",
+    "startup": "'export LD_LIBRARY_PATH=.; .\/7DaysToDieServer.x86_64 -configfile=serverconfig.xml -quit -batchmode -nographics -dedicated -ServerPort=$SERVER_PORT -ServerMaxPlayerCount=$MAX_PLAYERS -GameDifficulty=$GAME_DIFFICULTY -ControlPanelEnabled=false -TelnetEnabled=true -TelnetPort=8081 -logfile logs\/latest.log & echo -e \"Checing on telnet connection\" && until nc -z -v -w5 127.0.0.1 8081; do echo \"Waiting for telnet connection...\"; sleep 5; done && telnet -E 127.0.0.1 8081'",
     "config": {
         "files": "{}",
         "startup": "{\r\n    \"done\": \"Connected with 7DTD server\",\r\n    \"userInteraction\": []\r\n}",


### PR DESCRIPTION
Added LD_birary_path to startup command so the new alpha 18 build doesn't hang on init.

The new (alpha 18) 7days2die server wouldn't startup and would stay in a failed init state.
Adding the library path fixes the problem. The problem also occurs on other game eggs with the same engine (maybe it helps others). 

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:


### Changes to an existing Egg:

1. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [x] Have you tested your Egg changes?
