### PR TITLE
add ld lib path to 7dtd

### DIFF
--- a/steamcmd_servers/7_days_to_die/egg-7-days-to-die.json
+++ b/steamcmd_servers/7_days_to_die/egg-7-days-to-die.json
@@ -3,7 +3,7 @@
     "meta": {
         "version": "PTDL_v1"
     },
-    "exported_at": "2019-08-30T20:42:59-04:00",
+    "exported_at": "2019-10-24T00:07:13-04:00",
     "name": "7 Days To Die",
     "author": "kristoffer.norman@bahnhof.se",
     "description": "7 days to die server",
@@ -58,6 +58,15 @@
             "user_viewable": 1,
             "user_editable": 1,
             "rules": "required|boolean"
+        },
+        {
+            "name": "ld lib path",
+            "description": "This is really annoying that more games are doing this.",
+            "env_variable": "LD_LIBRARY_PATH",
+            "default_value": ".",
+            "user_viewable": 0,
+            "user_editable": 0,
+            "rules": "required|string|max:20"
         }
     ]
 }


### PR DESCRIPTION
adds a variable to set the ld lib path for version 18.

This is becoming a standard change for many servers.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

### Changes to an existing Egg:

1. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [x] Have you tested your Egg changes?
