### PR TITLE
Update egg-counter--strike--global-offensive.json

### DIFF
--- a/stock-eggs/source-engine/egg-counter--strike--global-offensive.json
+++ b/stock-eggs/source-engine/egg-counter--strike--global-offensive.json
@@ -3,12 +3,12 @@
     "meta": {
         "version": "PTDL_v1"
     },
-    "exported_at": "2018-06-19T07:46:06-04:00",
+    "exported_at": "2019-12-13T15:42:55+01:00",
     "name": "Counter-Strike: Global Offensive",
     "author": "support@pterodactyl.io",
     "description": "Counter-Strike: Global Offensive is a multiplayer first-person shooter video game developed by Hidden Path Entertainment and Valve Corporation.",
     "image": "quay.io\/pterodactyl\/core:source",
-    "startup": ".\/srcds_run -game csgo -console -port {{SERVER_PORT}} +ip 0.0.0.0 +map {{SRCDS_MAP}} -strictportbind -norestart +sv_setsteamaccount {{STEAM_ACC}}",
+    "startup": ".\/srcds_run -game csgo -console -usercon -port {{SERVER_PORT}} +ip 0.0.0.0 +game_type {{GAMETYPE}} +game_mode {{GAMEMODE}} +map {{SRCDS_MAP}} -maxplayers_override {{MAXPLAYERS}} -tickrate {{TICK}} -strictportbind -norestart +sv_setsteamaccount {{STEAM_ACC}}",
     "config": {
         "files": "{}",
         "startup": "{\r\n    \"done\": \"Connection to Steam servers successful\",\r\n    \"userInteraction\": []\r\n}",
@@ -39,7 +39,7 @@
             "default_value": "",
             "user_viewable": 1,
             "user_editable": 1,
-            "rules": "required|string|alpha_num|size:32"
+            "rules": "nullable|string|alpha_num|size:32"
         },
         {
             "name": "Source AppID",
@@ -49,6 +49,42 @@
             "user_viewable": 0,
             "user_editable": 0,
             "rules": "required|string|max:20"
+        },
+        {
+            "name": "Tick",
+            "description": "Server Tickrate",
+            "env_variable": "TICK",
+            "default_value": "64",
+            "user_viewable": 1,
+            "user_editable": 1,
+            "rules": "required|integer"
+        },
+        {
+            "name": "Game Type",
+            "description": "https:\/\/developer.valvesoftware.com\/wiki\/CSGO_Game_Mode_Commands",
+            "env_variable": "GAMETYPE",
+            "default_value": "0",
+            "user_viewable": 1,
+            "user_editable": 1,
+            "rules": "required|integer|max:1"
+        },
+        {
+            "name": "Game Mode",
+            "description": "https:\/\/developer.valvesoftware.com\/wiki\/CSGO_Game_Mode_Commands",
+            "env_variable": "GAMEMODE",
+            "default_value": "1",
+            "user_viewable": 1,
+            "user_editable": 1,
+            "rules": "required|integer|max:1"
+        },
+        {
+            "name": "Max Players",
+            "description": "Max Players allowed to connect",
+            "env_variable": "MAXPLAYERS",
+            "default_value": "10",
+            "user_viewable": 1,
+            "user_editable": 0,
+            "rules": "required|integer"
         }
     ]
 }


### PR DESCRIPTION
- Added -usercon to startup command due to remote rcon not working.

- Made GSLT not required, serverproviders are unable to generate a GSLT for their "customers" and the server is starting anyway in LAN-mode with a message saying to obtain a GSLT.

- Added tick and gamemodes variables

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [ ] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Server Submissions:

1. [x] Does your submission pass tests (server is connectable)?
2. [ ] Does your server use a custom docker image?
    * [ ] Have you tried to use a generic image?
    * [ ] Did you PR the necessary changes to make it work?
3. [ ] Have you added the server to the main README.md?
4. [ ] Have you added a unique README.md for the server you are adding?

### Changes to an existing Egg:

1. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [x] Have you tested your Egg changes?
