### PR TITLE
change pocketmine image

### DIFF
--- a/minecraft_bedrock/pocketmine_mp/egg-pocketmine-m-p.json
+++ b/minecraft_bedrock/pocketmine_mp/egg-pocketmine-m-p.json
@@ -3,11 +3,11 @@
     "meta": {
         "version": "PTDL_v1"
     },
-    "exported_at": "2020-01-02T00:07:42-05:00",
+    "exported_at": "2020-01-24T08:59:24-05:00",
     "name": "PocketmineMP",
     "author": "info@swisscrafting.ch",
     "description": "Pocketmine Egg\r\nby onekintaro from swisscrafting.ch\r\nwith the nice help from #eggs Channel on Pterodactyl-Discord :)",
-    "image": "quay.io\/parkervcp\/pterodactyl-images:ubuntu",
+    "image": "quay.io\/parkervcp\/pterodactyl-images:base_ubuntu",
     "startup": ".\/bin\/php7\/bin\/php .\/PocketMine-MP.phar --no-wizard --disable-ansi",
     "config": {
         "files": "{\r\n    \"server.properties\": {\r\n        \"parser\": \"properties\",\r\n        \"find\": {\r\n            \"server-ip\": \"0.0.0.0\",\r\n            \"enable-query\": \"true\",\r\n            \"server-port\": \"{{server.build.default.port}}\",\r\n            \"query.port\": \"{{server.build.default.port}}\"\r\n        }\r\n    }\r\n}",


### PR DESCRIPTION
changes the running image to `quay.io/parkervcp/pterodactyl-images:base_ubuntu`

### All Submissions:
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

### Changes to an existing Egg:
1. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [x] Have you tested your Egg changes?
