### PR TITLE
Update download link for Cuberite to generic source

### DIFF
--- a/minecraft_java/cuberite/egg-cuberite.json
+++ b/minecraft_java/cuberite/egg-cuberite.json
@@ -17,7 +17,7 @@
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/ash\r\n# Cuberite\r\n#\r\n# Server Files: \/mnt\/server\r\napt update\r\napt install -y wget\r\n\r\ncd \/mnt\/server\r\n\r\nwget https:\/\/builds.cuberite.org\/job\/Cuberite%20Linux%20x64%20Master\/lastSuccessfulBuild\/artifact\/Cuberite.tar.gz\r\n\r\ntar --strip-components=1 -xf Cuberite.tar.gz",
+            "script": "#!\/bin\/ash\r\n# Cuberite\r\n#\r\n# Server Files: \/mnt\/server\r\napt update\r\napt install -y wget\r\n\r\ncd \/mnt\/server\r\n\r\nwget https:\/\/download.cuberite.org\/linux-x86_64\/Cuberite.tar.gz\r\n\r\ntar --strip-components=1 -xf Cuberite.tar.gz",
             "container": "debian:buster-slim",
             "entrypoint": "bash"
         }


### PR DESCRIPTION
Cuberite has recently gained a redirect server for download links. Now this download location is robust against changes to the buildserver or main project URL.

### All Submissions:

* [*] Have you followed the guidelines in our Contributing document?
* [*] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [*] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

### Changes to an existing Egg:

1. [*] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [*] Have you tested your Egg changes?
