### PR TITLE
Update Discord.js generic egg to NodeJS v12

### DIFF
--- a/bots/discord/discord.js/egg-discord-js-generic.json
+++ b/bots/discord/discord.js/egg-discord-js-generic.json
@@ -3,11 +3,11 @@
     "meta": {
         "version": "PTDL_v1"
     },
-    "exported_at": "2020-02-01T21:36:43-05:00",
+    "exported_at": "2020-03-26T16:10:33+01:00",
     "name": "discord.js generic",
     "author": "parker@parkervcp.com",
     "description": "a generic discord js bot egg\r\n\r\nThis will clone a git repo for a bot. it defaults to master if no branch is specified.\r\n\r\nInstalls the node_modules on install. If you set user_upload then I assume you know what you are doing.",
-    "image": "quay.io\/parkervcp\/pterodactyl-images:debian_nodejs-10",
+    "image": "quay.io\/parkervcp\/pterodactyl-images:debian_nodejs-12",
     "startup": "if [[ -d .git ]] && [[ {{AUTO_UPDATE}} == \"1\" ]]; then git pull; fi && \/usr\/local\/bin\/npm install --production && \/usr\/local\/bin\/node \/home\/container\/{{BOT_JS_FILE}}",
     "config": {
         "files": "{}",


### PR DESCRIPTION
The new Discord.js update requires NodeJS v12 so I updated the egg to use the v12 image

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

### Changes to an existing Egg:

1. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [x] Have you tested your Egg changes?
