### PR TITLE
Update/typhoonlimbo

### DIFF
--- a/minecraft_proxy/typhoonlimbo/egg-typhoon-limbo.json
+++ b/minecraft_proxy/typhoonlimbo/egg-typhoon-limbo.json
@@ -3,11 +3,11 @@
     "meta": {
         "version": "PTDL_v1"
     },
-    "exported_at": "2019-07-15T23:01:54-04:00",
+    "exported_at": "2020-06-20T11:37:02-04:00",
     "name": "TyphoonLimbo",
     "author": "parker@parkervcp.com",
     "description": "Lightweight minecraft limbo server",
-    "image": "quay.io\/parkervcp\/pterodactyl-images:base_alpine",
+    "image": "quay.io\/parkervcp\/pterodactyl-images:base_debian",
     "startup": "`sleep 2 && .\/TyphoonLimbo`",
     "config": {
         "files": "{\r\n    \"config.json\": {\r\n        \"parser\": \"json\",\r\n        \"find\": {\r\n            \"listen_address\": \":{{server.build.default.port}}\"\r\n        }\r\n    }\r\n}",
@@ -17,9 +17,9 @@
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/ash\r\n# TyphoonLimbo Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\nexport GOPATH=$HOME\/go\r\nexport PATH=$GOROOT\/bin:$GOPATH\/bin:$PATH\r\n\r\napk add --no-cache --update git curl\r\n\r\ncd \/tmp\/\r\n\r\necho \"pulling the TyphoonLimbo pterodactyl branch\"\r\n\r\ngit clone https:\/\/github.com\/TyphoonMC\/TyphoonLimbo.git\r\ncd TyphoonLimbo\r\n\r\ngo get github.com\/TyphoonMC\/TyphoonCore\r\n\r\necho -e \"building TyphoonLimbo\"\r\ngo build\r\n\r\nmv TyphoonLimbo \/mnt\/server\/\r\n\r\nif [ -f \/mnt\/server\/config.json ]; then\r\n\techo -e \"config exists nothing to do\"\r\nelse\r\n\techo -e \"copying default config over\"\r\n\tcp config.json \/mnt\/server\/\r\nfi\r\n\r\necho -e \"install complete\"",
-            "container": "golang:1.12-alpine",
-            "entrypoint": "ash"
+            "script": "#!\/bin\/bash\r\n# TyphoonLimbo Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\nexport GOPATH=$HOME\/go\r\nexport PATH=$GOROOT\/bin:$GOPATH\/bin:$PATH\r\n\r\napt update\r\napt install -y git curl\r\n\r\ncd \/tmp\/\r\n\r\necho \"pulling the TyphoonLimbo pterodactyl branch\"\r\n\r\ngit clone https:\/\/github.com\/TyphoonMC\/TyphoonLimbo.git\r\ncd TyphoonLimbo\r\n\r\ngo get github.com\/TyphoonMC\/TyphoonCore\r\n\r\necho -e \"building TyphoonLimbo\"\r\ngo build\r\n\r\nmv TyphoonLimbo \/mnt\/server\/\r\n\r\nif [ -f \/mnt\/server\/config.json ]; then\r\n\techo -e \"config exists nothing to do\"\r\nelse\r\n\techo -e \"copying default config over\"\r\n\tcp config.json \/mnt\/server\/\r\nfi\r\n\r\necho -e \"install complete\"",
+            "container": "golang:1.14-buster",
+            "entrypoint": "bash"
         }
     },
     "variables": []


### PR DESCRIPTION
Update to use go 1.14 and the debian buster based image.

currently the install fails on 1.12

### All Submissions:
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

### Changes to an existing Egg:
1. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [x] Have you tested your Egg changes?
