### PR TITLE
add flag for windows app install

### DIFF
--- a/scripts/steamcmd_installer.sh
+++ b/scripts/steamcmd_installer.sh
@@ -3,6 +3,17 @@
 #
 # Server Files: /mnt/server
 # Image to install with is 'debian:buster-slim'
+
+##
+#
+# Variables
+# STEAM_USER, STEAM_PASS, STEAM_AUTH - Steam user setup. If a user has 2fa enabled it will most likely fail due to timeout. Leave blank for anon install.
+# WINDOWS_INSTALL - if it's a windows server you want to install set to 1
+# SRCDS_APPID - steam app id ffound here - https://developer.valvesoftware.com/wiki/Dedicated_Servers_List
+# EXTRA_FLAGS - when a server has extra glas for things like beta installs or updates.
+#
+##
+
 apt -y update
 apt -y --no-install-recommends install curl lib32gcc1 ca-certificates
 
@@ -30,7 +41,7 @@ chown -R root:root /mnt
 export HOME=/mnt/server
 
 ## install game using steamcmd
-./steamcmd.sh +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} +force_install_dir /mnt/server +app_update ${SRCDS_APPID} ${EXTRA_FLAGS} validate +quit ## other flags may be needed depending on install. looking at you cs 1.6
+./steamcmd.sh +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} $( [ "${WINDOWS_INSTALL}" == "1" ] || printf %s '+@sSteamCmdForcePlatformType windows' ) +force_install_dir /mnt/server +app_update ${SRCDS_APPID} ${EXTRA_FLAGS} validate +quit ## other flags may be needed depending on install. looking at you cs 1.6
 
 ## set up 32 bit libraries
 mkdir -p /mnt/server/.steam/sdk32


### PR DESCRIPTION
adds a `WINDOWS_INSTALL` flag to the install script.

adds notes on the variables in the script.

### All Submissions:
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:
