### PR TITLE
Allow support for private repos in the discord.js egg + small wording changes + fix inconsistencies with discord.py

### DIFF
--- a/bots/discord/discord.js/egg-discord-js-generic.json
+++ b/bots/discord/discord.js/egg-discord-js-generic.json
@@ -3,7 +3,7 @@
     "meta": {
         "version": "PTDL_v1"
     },
-    "exported_at": "2020-07-18T23:13:34-04:00",
+    "exported_at": "2020-08-13T22:04:35-04:00",
     "name": "discord.js generic",
     "author": "parker@parkervcp.com",
     "description": "a generic discord js bot egg\r\n\r\nThis will clone a git repo for a bot. it defaults to master if no branch is specified.\r\n\r\nInstalls the node_modules on install. If you set user_upload then I assume you know what you are doing.",
@@ -17,7 +17,7 @@
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/bash\r\n# NodeJS Bot Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\napt update\r\napt install -y git make gcc g++ python python-dev libtool\r\n\r\nmkdir -p \/mnt\/server\r\ncd \/mnt\/server\r\n\r\nif [[ ! ${INSTALL_REPO} = *\\.git ]]; then\r\n  INSTALL_REPO=$(echo -e ${INSTALL_REPO} | sed 's:\/*$::')\r\n  INSTALL_REPO=\"${INSTALL_REPO}.git\"\r\nfi\r\n\r\necho -e \"working on installing a discord.js bot from ${INSTALL_REPO}\"\r\n\r\nif [ \"${USER_UPLOAD}\" == \"true\" ] || [ \"${USER_UPLOAD}\" == \"1\" ]; then\r\n\techo -e \"assuming user knows what they are doing have a good day.\"\r\n\texit 0\r\nelse\r\n\tif [ \"$(ls -A \/mnt\/server)\" ]; then\r\n\t\techo -e \"\/mnt\/server directory is not empty.\"\r\n\t     if [ -d .git ]; then\r\n\t\t\techo -e \".git directory exists\" \r\n\t\t\tif [ -f .git\/config ]; then\r\n\t\t\t\techo -e \"loading info from git config\"\r\n\t\t\t\tORIGIN=$(git config --get remote.origin.url)\r\n\t\t\telse\r\n\t\t\t\techo -e \"files found with no git config\"\r\n\t\t\t\techo -e \"closing out without touching things to not break anything\"\r\n\t\t\t\texit 10\r\n\t\t\tfi\r\n\t\tfi\r\n\t\tif [ \"${ORIGIN}\" == \"${INSTALL_REPO}\" ]; then\r\n\t\t\techo \"pulling latest from github\"\r\n\t\t\tgit pull \r\n\t\tfi\r\n\telse\r\n    \techo -e \"\/mnt\/server is empty.\\ncloning files into repo\"\r\n\t\tif [ -z ${INSTALL_BRANCH} ]; then\r\n\t\t\techo -e \"assuming master branch\"\r\n\t\t\tINSTALL_BRANCH=master\r\n\t\tfi\r\n        \r\n\t\techo -e \"running 'git clone --single-branch --branch ${INSTALL_BRANCH} ${INSTALL_REPO} .'\"\r\n\t\tgit clone --single-branch --branch ${INSTALL_BRANCH} ${INSTALL_REPO} .\r\n\tfi\r\nfi \r\n\r\necho \"Installing python requirements into folder\"\r\nif [[ ! -z ${NODE_PACKAGES} ]]; then\r\n    \/usr\/local\/bin\/npm install ${NODE_PACKAGES}\r\nfi\r\n\r\nif [ -f \/mnt\/server\/package.json ]; then\r\n    \/usr\/local\/bin\/npm install --production\r\nfi\r\n\r\necho -e \"install complete\"\r\nexit 0",
+            "script": "#!\/bin\/bash\r\n# NodeJS Bot Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\napt update\r\napt install -y git make gcc g++ python python-dev libtool\r\n\r\nmkdir -p \/mnt\/server\r\ncd \/mnt\/server\r\n\r\nif [[ ! \"${USERNAME}\" == \"\" ]]; then\r\n    if [[ ! https:\/\/${USERNAME}:${PASSWORD}@github.com\/${INSTALL_REPO}.git = *\\.git ]]; then\r\n      INSTALL_REPO=$(echo -e https:\/\/${USERNAME}:${PASSWORD}@github.com\/${INSTALL_REPO}.git | sed 's:\/*$::')\r\n      INSTALL_REPO=\"https:\/\/${USERNAME}:${PASSWORD}@github.com\/${INSTALL_REPO}.git\"\r\n    fi\r\n    \r\n    echo -e \"working on installing a discord.js bot from https:\/\/${USERNAME}:${PASSWORD}@github.com\/${INSTALL_REPO}.git\"\r\n    \r\n    if [ \"${USER_UPLOAD}\" == \"true\" ] || [ \"${USER_UPLOAD}\" == \"1\" ]; then\r\n    \techo -e \"assuming user knows what they are doing have a good day.\"\r\n    \texit 0\r\n    else\r\n    \tif [ \"$(ls -A \/mnt\/server)\" ]; then\r\n    \t\techo -e \"\/mnt\/server directory is not empty.\"\r\n    \t     if [ -d .git ]; then\r\n    \t\t\techo -e \".git directory exists\" \r\n    \t\t\tif [ -f .git\/config ]; then\r\n    \t\t\t\techo -e \"loading info from git config\"\r\n    \t\t\t\tORIGIN=$(git config --get remote.origin.url)\r\n    \t\t\telse\r\n    \t\t\t\techo -e \"files found with no git config\"\r\n    \t\t\t\techo -e \"closing out without touching things to not break anything\"\r\n    \t\t\t\texit 10\r\n    \t\t\tfi\r\n    \t\tfi\r\n    \t\tif [ \"${ORIGIN}\" == \"https:\/\/${USERNAME}:${PASSWORD}@github.com\/${INSTALL_REPO}.git\" ]; then\r\n    \t\t\techo \"pulling latest from github\"\r\n    \t\t\tgit pull \r\n    \t\tfi\r\n    \telse\r\n        \techo -e \"\/mnt\/server is empty.\\ncloning files into repo\"\r\n    \t\tif [ -z ${INSTALL_BRANCH} ]; then\r\n    \t\t\techo -e \"assuming master branch\"\r\n    \t\t\tINSTALL_BRANCH=master\r\n    \t\tfi\r\n            \r\n    \t\techo -e \"running 'git clone --single-branch --branch ${INSTALL_BRANCH} https:\/\/${USERNAME}:${PASSWORD}@github.com\/${INSTALL_REPO}.git .'\"\r\n    \t\tgit clone --single-branch --branch ${INSTALL_BRANCH} https:\/\/${USERNAME}:${PASSWORD}@github.com\/${INSTALL_REPO}.git .\r\n    \tfi\r\n    fi \r\nelse\r\n    if [[ ! ${INSTALL_REPO} = *\\.git ]]; then\r\n      INSTALL_REPO=$(echo -e ${INSTALL_REPO} | sed 's:\/*$::')\r\n      INSTALL_REPO=\"${INSTALL_REPO}.git\"\r\n    fi\r\n    \r\n    echo -e \"working on installing a discord.js bot from ${INSTALL_REPO}\"\r\n    \r\n    if [ \"${USER_UPLOAD}\" == \"true\" ] || [ \"${USER_UPLOAD}\" == \"1\" ]; then\r\n    \techo -e \"assuming user knows what they are doing have a good day.\"\r\n    \texit 0\r\n    else\r\n    \tif [ \"$(ls -A \/mnt\/server)\" ]; then\r\n    \t\techo -e \"\/mnt\/server directory is not empty.\"\r\n    \t     if [ -d .git ]; then\r\n    \t\t\techo -e \".git directory exists\" \r\n    \t\t\tif [ -f .git\/config ]; then\r\n    \t\t\t\techo -e \"loading info from git config\"\r\n    \t\t\t\tORIGIN=$(git config --get remote.origin.url)\r\n    \t\t\telse\r\n    \t\t\t\techo -e \"files found with no git config\"\r\n    \t\t\t\techo -e \"closing out without touching things to not break anything\"\r\n    \t\t\t\texit 10\r\n    \t\t\tfi\r\n    \t\tfi\r\n    \t\tif [ \"${ORIGIN}\" == \"${INSTALL_REPO}\" ]; then\r\n    \t\t\techo \"pulling latest from github\"\r\n    \t\t\tgit pull \r\n    \t\tfi\r\n    \telse\r\n        \techo -e \"\/mnt\/server is empty.\\ncloning files into repo\"\r\n    \t\tif [ -z ${INSTALL_BRANCH} ]; then\r\n    \t\t\techo -e \"assuming master branch\"\r\n    \t\t\tINSTALL_BRANCH=master\r\n    \t\tfi\r\n            \r\n    \t\techo -e \"running 'git clone --single-branch --branch ${INSTALL_BRANCH} ${INSTALL_REPO} .'\"\r\n    \t\tgit clone --single-branch --branch ${INSTALL_BRANCH} ${INSTALL_REPO} .\r\n    \tfi\r\n    fi \r\nfi\r\n\r\necho \"Installing python requirements into folder\"\r\nif [[ ! -z ${NODE_PACKAGES} ]]; then\r\n    \/usr\/local\/bin\/npm install ${NODE_PACKAGES}\r\nfi\r\n\r\nif [ -f \/mnt\/server\/package.json ]; then\r\n    \/usr\/local\/bin\/npm install --production\r\nfi\r\n\r\necho -e \"install complete\"\r\nexit 0",
             "container": "node:12-buster-slim",
             "entrypoint": "bash"
         }
@@ -25,34 +25,52 @@
     "variables": [
         {
             "name": "Install Repo",
-            "description": "The git repo to clone and install the discord js bot from",
+            "description": "The GitHub repo to clone and install the discord js bot from.",
             "env_variable": "INSTALL_REPO",
             "default_value": "",
             "user_viewable": 1,
-            "user_editable": 0,
+            "user_editable": 1,
+            "rules": "nullable|string|max:128"
+        },
+        {
+            "name": "Username",
+            "description": "The GitHub username. Leave this field blank if the GitHub repo is NOT a private repo.",
+            "env_variable": "USERNAME",
+            "default_value": "",
+            "user_viewable": 1,
+            "user_editable": 1,
+            "rules": "nullable|string|max:128"
+        },
+        {
+            "name": "Password",
+            "description": "The GitHub password. Leave this field blank if the GitHub repo is NOT a private repo.",
+            "env_variable": "PASSWORD",
+            "default_value": "",
+            "user_viewable": 1,
+            "user_editable": 1,
             "rules": "nullable|string|max:128"
         },
         {
             "name": "Install Branch",
-            "description": "The branch of the bot to install",
+            "description": "The branch of the bot to install.",
             "env_variable": "INSTALL_BRANCH",
             "default_value": "",
             "user_viewable": 1,
-            "user_editable": 0,
+            "user_editable": 1,
             "rules": "nullable|string|max:32"
         },
         {
             "name": "User Uploaded Files",
-            "description": "Skip all the install cruft is you are just letting a user upload files.\r\n\r\n0 = false (default)\r\n1 = true",
+            "description": "Skip all the install stuff if you are letting a user upload files.\r\n\r\n0 = false (default)\r\n1 = true",
             "env_variable": "USER_UPLOAD",
             "default_value": "0",
             "user_viewable": 1,
-            "user_editable": 0,
+            "user_editable": 1,
             "rules": "required|bool"
         },
         {
             "name": "Auto Update",
-            "description": "When using a git repo pull the latest files on startup.",
+            "description": "Pull the latest files on startup when using a GitHub repo.",
             "env_variable": "AUTO_UPDATE",
             "default_value": "0",
             "user_viewable": 1,
@@ -70,7 +88,7 @@
         },
         {
             "name": "Additional Node packages",
-            "description": "Install additional node packages.\r\n\r\nUse spaces to separate",
+            "description": "Install additional node packages.\r\n\r\nUse spaces to separate.",
             "env_variable": "NODE_PACKAGES",
             "default_value": "",
             "user_viewable": 1,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to an existing Egg:

1. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
     Adds support for private repos and changes some wording. For example, it fixes a typo and changes some instances of "git" to "GitHub" to help out people with limited experience. It also fixes an inconsistency with the discord.py egg where users could not edit the values for the discord.js egg but could on the discord.py egg. If this was intentional, feel free to undo those changes.
2. [x] Have you tested your Egg changes?
It'd be helpful if someone could try this with a public repository since I was unable to find a discord.js bot in a public repo and my bot has a lot of confidential info hardcoded into it. It works fine with private repos and there seems to be no reason why it wouldn't work with public repos since I didn't change anything with respect to those.