### PR TITLE
Updated Compatibility with Velocity 1.x.x

### DIFF
--- a/minecraft/proxy/java/velocity/egg-velocity.json
+++ b/minecraft/proxy/java/velocity/egg-velocity.json
@@ -8,7 +8,7 @@
     "author": "parker@parkervcp.com",
     "description": "Velocity is a Minecraft server proxy with unparalleled server support, scalability, and flexibility.",
     "features": null,
-    "image": "quay.io\/discoversquishy\/dockerimages:openjdk-15-hostpot",
+    "image": "quay.io\/parkervcp\/pterodactyl-images:adoptopenjdk-15-hotspot",
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -XX:+UseG1GC -XX:G1HeapRegionSize=4M -XX:+UnlockExperimentalVMOptions -XX:+ParallelRefProcEnabled -XX:+AlwaysPreTouch -XX:MaxInlineLevel=15 -jar {{SERVER_JARFILE}}",
     "config": {
         "files": "{\r\n    \"velocity.toml\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"bind = \": \"bind = \\\"0.0.0.0:{{server.build.default.port}}\\\"\"\r\n        }\r\n    }\r\n}",

--- a/minecraft/proxy/java/velocity/egg-velocity.json
+++ b/minecraft/proxy/java/velocity/egg-velocity.json
@@ -3,13 +3,13 @@
     "meta": {
         "version": "PTDL_v1"
     },
-    "exported_at": "2020-11-21T14:09:45-05:00",
+    "exported_at": "2020-11-22T01:50:29-05:00",
     "name": "Velocity",
     "author": "parker@parkervcp.com",
     "description": "Velocity is a Minecraft server proxy with unparalleled server support, scalability, and flexibility.",
     "features": null,
-    "image": "quay.io\/pterodactyl\/core:java",
-    "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",
+    "image": "quay.io\/discoversquishy\/dockerimages:openjdk-15-hostpot",
+    "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -XX:+UseG1GC -XX:G1HeapRegionSize=4M -XX:+UnlockExperimentalVMOptions -XX:+ParallelRefProcEnabled -XX:+AlwaysPreTouch -XX:MaxInlineLevel=15 -jar {{SERVER_JARFILE}}",
     "config": {
         "files": "{\r\n    \"velocity.toml\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"bind = \": \"bind = \\\"0.0.0.0:{{server.build.default.port}}\\\"\"\r\n        }\r\n    }\r\n}",
         "startup": "{\r\n    \"done\": \"Done (\"\r\n}",
@@ -18,14 +18,15 @@
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/ash\r\n# Velocity Proxy Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\n\r\napk add --no-cache curl\r\n\r\nmkdir -p \/mnt\/server\/\r\n\r\ncd \/mnt\/server\/\r\n\r\nif [ -z ${VELOCITY_VERSION} ] || [ ${VELOCITY_VERSION} == \"latest\" ]; then\r\n\tVELOCITY_VERSION=\/latest\r\nfi\r\n\r\necho -e \"Getting download link\"\r\nDOWNLOAD_ENDPOINT=$(curl https:\/\/versions.velocitypowered.com\/download\/${VELOCITY_VERSION}\/ | grep -Eo 'href=\"[^\\\"]+\"' | grep -vE \"view|fingerprint\" | grep \".jar\" | sed -n 's\/.*href=\"\\([^\"]*\\).*\/\\1\/p')\r\nDOWNLOAD_LINK=https:\/\/versions.velocitypowered.com\/download\/${DOWNLOAD_ENDPOINT}\r\n\r\necho -e \"Downloading ${DOWNLOAD_LINK}\"\r\ncurl ${DOWNLOAD_LINK} -o ${SERVER_JARFILE}\r\n\r\nif [ -f velocity.toml ]; then\r\n    echo -e \"velocity config file exists\"\r\nelse\r\n    echo -e \"downloading velocity config file.\"\r\n    curl https:\/\/raw.githubusercontent.com\/parkervcp\/eggs\/master\/minecraft\/proxy\/proxy\/velocity\/velocity.toml -o velocity.toml\r\nfi\r\n\r\necho -e \"install complete\"",
+            "script": "#!\/bin\/ash\r\n# Velocity Proxy Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\n\r\napk add --no-cache curl\r\n\r\nmkdir -p \/mnt\/server\/\r\n\r\ncd \/mnt\/server\/\r\n\r\nif [ -z ${VELOCITY_VERSION} ] || [ ${VELOCITY_VERSION} == \"latest\" ]; then\r\n\tVELOCITY_VERSION=\"latest\"\r\nfi\r\n\r\necho -e \"Getting download link\"\r\nDOWNLOAD_LINK=https:\/\/versions.velocitypowered.com\/download\/${VELOCITY_VERSION}\r\n\r\necho -e \"Downloading ${DOWNLOAD_LINK}\"\r\ncurl ${DOWNLOAD_LINK} -o ${SERVER_JARFILE}\r\n\r\nif [ -f velocity.toml ]; then\r\n    echo -e \"velocity config file exists\"\r\nelse\r\n    echo -e \"downloading velocity config file.\"\r\n    curl https:\/\/raw.githubusercontent.com\/parkervcp\/eggs\/master\/minecraft\/proxy\/java\/velocity\/velocity.toml -o velocity.toml\r\nfi\r\n\r\necho -e \"install complete\"",
             "container": "alpine:3.10",
             "entrypoint": "ash"
         }
     },
-    "variables": [{
+    "variables": [
+        {
             "name": "Velocity Version",
-            "description": "The Velocity Proxy version to download.\r\n\r\nset to 'latest ' the download the last stable build.",
+            "description": "The Velocity Proxy version to download.\r\n\r\nSet to 'latest ' the download the last stable build.\r\nSet to '1.1.x-SNAPSHOT' to get the latest dev build.",
             "env_variable": "VELOCITY_VERSION",
             "default_value": "latest",
             "user_viewable": true,
@@ -34,7 +35,7 @@
         },
         {
             "name": "Server Jar File",
-            "description": "Server Jar File name",
+            "description": "Server Jarfile, by default this is set to 'velocity.jar'.\r\nSet it to otherwise if you wish to have a different jarfile name.",
             "env_variable": "SERVER_JARFILE",
             "default_value": "velocity.jar",
             "user_viewable": true,

--- a/minecraft/proxy/java/velocity/egg-velocity.json
+++ b/minecraft/proxy/java/velocity/egg-velocity.json
@@ -3,33 +3,33 @@
     "meta": {
         "version": "PTDL_v1"
     },
-    "exported_at": "2019-07-14T20:36:29-04:00",
+    "exported_at": "2020-11-21T14:09:45-05:00",
     "name": "Velocity",
     "author": "parker@parkervcp.com",
     "description": "Velocity is a Minecraft server proxy with unparalleled server support, scalability, and flexibility.",
+    "features": null,
     "image": "quay.io\/pterodactyl\/core:java",
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",
     "config": {
         "files": "{\r\n    \"velocity.toml\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"bind = \": \"bind = \\\"0.0.0.0:{{server.build.default.port}}\\\"\"\r\n        }\r\n    }\r\n}",
         "startup": "{\r\n    \"done\": \"Done (\"\r\n}",
         "logs": "{}",
-        "stop": "shutdown"
+        "stop": "end"
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/ash\r\n# Velocity Proxy Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\n\r\napk add --no-cache curl\r\n\r\nmkdir -p \/mnt\/server\/\r\n\r\ncd \/mnt\/server\/\r\n\r\nif [ -z ${VELOCITY_VERSION} ] || [ ${VELOCITY_VERSION} == \"latest\" ]; then\r\n\tVELOCITY_VERSION=\/lastStableBuild\r\nfi\r\n\r\necho -e \"Getting download link\"\r\nDOWNLOAD_ENDPOINT=$(curl https:\/\/ci.velocitypowered.com\/job\/velocity\/${VELOCITY_VERSION}\/ | grep -Eo 'href=\"[^\\\"]+\"' | grep -vE \"view|fingerprint\" | grep \".jar\" | sed -n 's\/.*href=\"\\([^\"]*\\).*\/\\1\/p')\r\nDOWNLOAD_LINK=https:\/\/ci.velocitypowered.com\/job\/velocity\/lastStableBuild\/${DOWNLOAD_ENDPOINT}\r\n\r\necho -e \"Downloading ${DOWNLOAD_LINK}\"\r\ncurl ${DOWNLOAD_LINK} -o ${SERVER_JARFILE}\r\n\r\nif [ -f velocity.toml ]; then\r\n    echo -e \"velocity config file exists\"\r\nelse\r\n    echo -e \"downloading velocity config file.\"\r\n    curl https:\/\/raw.githubusercontent.com\/parkervcp\/eggs\/master\/minecraft\/proxy\/proxy\/velocity\/velocity.toml -o velocity.toml\r\nfi\r\n\r\necho -e \"install complete\"",
+            "script": "#!\/bin\/ash\r\n# Velocity Proxy Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\n\r\napk add --no-cache curl\r\n\r\nmkdir -p \/mnt\/server\/\r\n\r\ncd \/mnt\/server\/\r\n\r\nif [ -z ${VELOCITY_VERSION} ] || [ ${VELOCITY_VERSION} == \"latest\" ]; then\r\n\tVELOCITY_VERSION=\/latest\r\nfi\r\n\r\necho -e \"Getting download link\"\r\nDOWNLOAD_ENDPOINT=$(curl https:\/\/versions.velocitypowered.com\/download\/${VELOCITY_VERSION}\/ | grep -Eo 'href=\"[^\\\"]+\"' | grep -vE \"view|fingerprint\" | grep \".jar\" | sed -n 's\/.*href=\"\\([^\"]*\\).*\/\\1\/p')\r\nDOWNLOAD_LINK=https:\/\/versions.velocitypowered.com\/download\/${DOWNLOAD_ENDPOINT}\r\n\r\necho -e \"Downloading ${DOWNLOAD_LINK}\"\r\ncurl ${DOWNLOAD_LINK} -o ${SERVER_JARFILE}\r\n\r\nif [ -f velocity.toml ]; then\r\n    echo -e \"velocity config file exists\"\r\nelse\r\n    echo -e \"downloading velocity config file.\"\r\n    curl https:\/\/raw.githubusercontent.com\/parkervcp\/eggs\/master\/minecraft\/proxy\/proxy\/velocity\/velocity.toml -o velocity.toml\r\nfi\r\n\r\necho -e \"install complete\"",
             "container": "alpine:3.10",
             "entrypoint": "ash"
         }
     },
-    "variables": [
-        {
+    "variables": [{
             "name": "Velocity Version",
             "description": "The Velocity Proxy version to download.\r\n\r\nset to 'latest ' the download the last stable build.",
             "env_variable": "VELOCITY_VERSION",
             "default_value": "latest",
-            "user_viewable": 1,
-            "user_editable": 0,
+            "user_viewable": true,
+            "user_editable": false,
             "rules": "required|string|max:20"
         },
         {
@@ -37,8 +37,8 @@
             "description": "Server Jar File name",
             "env_variable": "SERVER_JARFILE",
             "default_value": "velocity.jar",
-            "user_viewable": 1,
-            "user_editable": 0,
+            "user_viewable": true,
+            "user_editable": false,
             "rules": "required|string|max:20"
         }
     ]

--- a/minecraft/proxy/java/velocity/velocity.toml
+++ b/minecraft/proxy/java/velocity/velocity.toml
@@ -25,12 +25,12 @@ prevent-client-proxy-connections = false
 #                  unable to implement network level firewalling (on a shared host).
 # - "modern":      Forward player IPs and UUIDs as part of the login process using
 #                  Velocity's native forwarding. Only applicable for Minecraft 1.13 or higher.
-player-info-forwarding-mode = "NONE"
+player-info-forwarding-mode = "legacy"
 # If you are using modern or BungeeGuard IP forwarding, configure an unique secret here.
-forwarding-secret = "pNuOOnPLzGd4"
+forwarding-secret = ""
 # Announce whether or not your server supports Forge. If you run a modded server, we
 # suggest turning this on.
-# 
+#
 # If your network runs one modpack consistently, consider using ping-passthrough = "mods"
 # instead for a nicer display in the server list.
 announce-forge = false
@@ -77,7 +77,7 @@ ping-passthrough = "DISABLED"
   # Enables compatibility with HAProxy.
   proxy-protocol = false
   # Enables TCP fast open support on the proxy. Requires the proxy to run on Linux.
-  tcp-fast-open = false
+  tcp-fast-open = true
   # Shows ping requests to the proxy from clients.
   show-ping-requests = false
   # By default, Velocity will attempt to gracefully handle situations where the user unexpectedly
@@ -118,7 +118,7 @@ ping-passthrough = "DISABLED"
   # player count. We recommend keeping bStats enabled, but if you're not comfortable with
   # this, you can turn this setting off. There is no performance penalty associated with
   # having metrics enabled, and data sent to bStats can't identify your server.
-  enabled = true
+  enabled = false
 
 # Legacy color codes and JSON are accepted in all messages.
 [messages]

--- a/minecraft/proxy/java/velocity/velocity.toml
+++ b/minecraft/proxy/java/velocity/velocity.toml
@@ -1,106 +1,135 @@
 # Config version. Do not change this
 config-version = "1.0"
-
 # What port should the proxy be bound to? By default, we'll bind to all addresses on port 25577.
 bind = "0.0.0.0:25577"
-
 # What should be the MOTD? This gets displayed when the player adds your server to
 # their server list. Legacy color codes and JSON are accepted.
 motd = "&3A Velocity Server"
-
 # What should we display for the maximum number of players? (Velocity does not support a cap
 # on the number of players online.)
 show-max-players = 500
-
 # Should we authenticate players with Mojang? By default, this is on.
 online-mode = true
-
+# If client's ISP/AS sent from this proxy is different from the one from Mojang's
+# authentication server, the player is kicked. This disallows some VPN and proxy
+# connections but is a weak form of protection.
+prevent-client-proxy-connections = false
 # Should we forward IP addresses and other data to backend servers?
 # Available options:
-# - "none":   No forwarding will be done. All players will appear to be connecting from the
-#             proxy and will have offline-mode UUIDs.
-# - "legacy": Forward player IPs and UUIDs in a BungeeCord-compatible format. Use this if
-#             you run servers using Minecraft 1.12 or lower.
-# - "modern": Forward player IPs and UUIDs as part of the login process using Velocity's 
-#             native forwarding. Only applicable for Minecraft 1.13 or higher.
+# - "none":        No forwarding will be done. All players will appear to be connecting
+#                  from the proxy and will have offline-mode UUIDs.
+# - "legacy":      Forward player IPs and UUIDs in a BungeeCord-compatible format. Use this
+#                  if you run servers using Minecraft 1.12 or lower.
+# - "bungeeguard": Forward player IPs and UUIDs in a format supported by the BungeeGuard
+#                  plugin. Use this if you run servers using Minecraft 1.12 or lower, and are
+#                  unable to implement network level firewalling (on a shared host).
+# - "modern":      Forward player IPs and UUIDs as part of the login process using
+#                  Velocity's native forwarding. Only applicable for Minecraft 1.13 or higher.
 player-info-forwarding-mode = "NONE"
-
-# If you are using modern IP forwarding, configure an unique secret here.
-forwarding-secret = "FrP42MxySW6Y"
-
+# If you are using modern or BungeeGuard IP forwarding, configure an unique secret here.
+forwarding-secret = "pNuOOnPLzGd4"
 # Announce whether or not your server supports Forge. If you run a modded server, we
 # suggest turning this on.
+# 
+# If your network runs one modpack consistently, consider using ping-passthrough = "mods"
+# instead for a nicer display in the server list.
 announce-forge = false
+# If enabled (default is false) and the proxy is in online mode, Velocity will kick
+# any existing player who is online if a duplicate connection attempt is made.
+kick-existing-players = false
+# Should Velocity pass server list ping requests to a backend server?
+# Available options:
+# - "disabled":    No pass-through will be done. The velocity.toml and server-icon.png
+#                  will determine the initial server list ping response.
+# - "mods":        Passes only the mod list from your backend server into the response.
+#                  The first server in your try list (or forced host) with a mod list will be
+#                  used. If no backend servers can be contacted, Velocity won't display any
+#                  mod information.
+# - "description": Uses the description and mod list from the backend server. The first
+#                  server in the try (or forced host) list that responds is used for the
+#                  description and mod list.
+# - "all":         Uses the backend server's response as the proxy response. The Velocity
+#                  configuration is used if no servers could be contacted.
+ping-passthrough = "DISABLED"
 
 [servers]
-# Configure your servers here. Each key represents the server's name, and the value
-# represents the IP address of the server to connect to.
-lobby = "127.0.0.1:30066"
-minigames = "127.0.0.1:30068"
-factions = "127.0.0.1:30067"
-
-# In what order we should try servers when a player logs in or is kicked from aserver.
-try = [
-  "lobby"
-]
+  # Configure your servers here. Each key represents the server's name, and the value
+  # represents the IP address of the server to connect to.
+  lobby = "127.0.0.1:30066"
+  minigames = "127.0.0.1:30068"
+  # In what order we should try servers when a player logs in or is kicked from aserver.
+  try = ["lobby"]
+  factions = "127.0.0.1:30067"
 
 [forced-hosts]
-# Configure your forced hosts here.
-"minigames.example.com" = [
-  "minigames"
-]
-"lobby.example.com" = [
-  "lobby"
-]
-"factions.example.com" = [
-  "factions"
-]
+  "minigames.example.com" = ["minigames"]
+  # Configure your forced hosts here.
+  "lobby.example.com" = ["lobby"]
+  "factions.example.com" = ["factions"]
 
 [advanced]
-# How large a Minecraft packet has to be before we compress it. Setting this to zero will
-# compress all packets, and setting it to -1 will disable compression entirely.
-compression-threshold = 256
-
-# How much compression should be done (from 0-9). The default is -1, which uses the
-# default level of 6.
-compression-level = -1
-
-# How fast (in milliseconds) are clients allowed to connect after the last connection? By
-# default, this is three seconds. Disable this by setting this to 0.
-login-ratelimit = 3000
-
-# Specify a custom timeout for connection timeouts here. The default is five seconds.
-connection-timeout = 5000
-
-# Specify a read timeout for connections here. The default is 30 seconds.
-read-timeout = 30000
-
-# Enables compatibility with HAProxy.
-proxy-protocol = false
+  # Specify a custom timeout for connection timeouts here. The default is five seconds.
+  connection-timeout = 5000
+  # Enables BungeeCord plugin messaging channel support on Velocity.
+  bungee-plugin-message-channel = true
+  # Specify a read timeout for connections here. The default is 30 seconds.
+  read-timeout = 30000
+  # Enables compatibility with HAProxy.
+  proxy-protocol = false
+  # Enables TCP fast open support on the proxy. Requires the proxy to run on Linux.
+  tcp-fast-open = false
+  # Shows ping requests to the proxy from clients.
+  show-ping-requests = false
+  # By default, Velocity will attempt to gracefully handle situations where the user unexpectedly
+  # loses connection to the server without an explicit disconnect message by attempting to fall the
+  # user back, except in the case of read timeouts. BungeeCord will disconnect the user instead. You
+  # can disable this setting to use the BungeeCord behavior.
+  failover-on-unexpected-server-disconnect = true
+  # How much compression should be done (from 0-9). The default is -1, which uses the
+  # default level of 6.
+  compression-level = -1
+  # Declares the proxy commands to 1.13+ clients.
+  announce-proxy-commands = true
+  # Enables the logging of commands
+  log-command-executions = false
+  # How large a Minecraft packet has to be before we compress it. Setting this to zero will
+  # compress all packets, and setting it to -1 will disable compression entirely.
+  compression-threshold = 256
+  # How fast (in milliseconds) are clients allowed to connect after the last connection? By
+  # default, this is three seconds. Disable this by setting this to 0.
+  login-ratelimit = 3000
 
 [query]
-# Whether to enable responding to GameSpy 4 query responses or not.
-enabled = false
-
-# If query is enabled, on what port should the query protocol listen on?
-port = 25577
-
-# This is the map name that is reported to the query services.
-map = "Velocity"
-
-# Whether plugins should be shown in query response by default or not
-show-plugins = false
+  # If query is enabled, on what port should the query protocol listen on?
+  port = 25577
+  # Whether plugins should be shown in query response by default or not
+  show-plugins = false
+  # This is the map name that is reported to the query services.
+  map = "Velocity"
+  # Whether to enable responding to GameSpy 4 query responses or not.
+  enabled = false
 
 [metrics]
-# Whether metrics will be reported to bStats (https://bstats.org).
-# bStats collects some basic information, like how many people use Velocity and their
-# player count. We recommend keeping bStats enabled, but if you're not comfortable with
-# this, you can turn this setting off. There is no performance penalty associated with
-# having metrics enabled, and data sent to bStats can't identify your server.
-enabled = true
+  # A unique, anonymous ID to identify this proxy with.
+  id = ""
+  log-failure = false
+  # Whether metrics will be reported to bStats (https://bstats.org).
+  # bStats collects some basic information, like how many people use Velocity and their
+  # player count. We recommend keeping bStats enabled, but if you're not comfortable with
+  # this, you can turn this setting off. There is no performance penalty associated with
+  # having metrics enabled, and data sent to bStats can't identify your server.
+  enabled = true
 
-# A unique, anonymous ID to identify this proxy with.
-id = "b12f2e77-133c-4a5f-b288-d8833be3dc4d"
-
-log-failure = false
-
+# Legacy color codes and JSON are accepted in all messages.
+[messages]
+  generic-connection-error = "&cAn internal error occurred in your connection."
+  already-connected = "&cYou are already connected to this proxy!"
+  online-mode-only = "&cThis server only accepts connections from online-mode clients.\n\n&7Did you change your username? Sign out of Minecraft, sign back in, and try again."
+  # Prefix when the player is disconnected from a server.
+  #   First argument '%s': the server name
+  disconnect-prefix = "&cCan't connect to %s: "
+  no-available-servers = "&cThere are no available servers."
+  # Prefix when the player gets kicked from a server.
+  #   First argument '%s': the server name
+  kick-prefix = "&cKicked from %s: "
+  moved-to-new-server-prefix = "&cThe server you were on kicked you: "


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes to an existing Egg:

1. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [x] Have you tested your Egg changes?

----


Pretty simple update, Velocity changed their CI server and started utilizing Cloudflare workers. Anyways, this update ensures that the server installation fully works with the LTS versions of Velocity. I've tested it and it seems to be running fine :).

However, @parkervcp are you able to modify & push your java image? Velocity suggests using AdoptOpenJDK's J11 HotSpot JVM as the java base image. However, they also mentioned that only on Java 15 it was mentioned that the GC HotSpot: ZGC has been declared as stable. So if you are going to create a new modified image with a different base, I'll leave you to decide if you want to go with J11 HotSpot or J15 HotSpot. 

One more thing, as for the suggested JVM flags by them which are:
```
-XX:+UseG1GC -XX:G1HeapRegionSize=4M -XX:+UnlockExperimentalVMOptions -XX:+ParallelRefProcEnabled -XX:+AlwaysPreTouch -XX:MaxInlineLevel=15
```
Is something I thought about modifying but thought it would be better to have this version of the egg run for a few weeks and see if anything goes sideways with using J11 or 15 with the new Velocity version arises. 
