### PR TITLE
Update curseforge to reference a working modpack

### DIFF
--- a/minecraft/java/forge/curseforge-generic/egg-curseforge-generic.json
+++ b/minecraft/java/forge/curseforge-generic/egg-curseforge-generic.json
@@ -3,10 +3,11 @@
     "meta": {
         "version": "PTDL_v1"
     },
-    "exported_at": "2020-08-12T08:19:04-04:00",
+    "exported_at": "2020-12-07T11:33:04-05:00",
     "name": "Curseforge Generic",
     "author": "parker@parkervcp.com",
     "description": "A generic egg for a forge modpack",
+    "features": null,
     "image": "quay.io\/pterodactyl\/core:java",
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar server.jar",
     "config": {
@@ -25,11 +26,11 @@
     "variables": [
         {
             "name": "modpack project ID",
-            "description": "The modpack project ID from the curseforge site on the pack page.\r\n\r\n(Ex. https:\/\/minecraft.curseforge.com\/projects\/sevtech-ages ID is 268208)",
+            "description": "The modpack project ID from the curseforge site on the pack page.\r\n\r\n(Ex. https:\/\/www.curseforge.com\/minecraft\/modpacks\/bofa-mods ID is 375152)",
             "env_variable": "MODPACK_ID",
             "default_value": "",
-            "user_viewable": 1,
-            "user_editable": 1,
+            "user_viewable": true,
+            "user_editable": true,
             "rules": "required|string"
         },
         {
@@ -37,8 +38,8 @@
             "description": "Version of the modpack to use.",
             "env_variable": "MODPACK_VERSION",
             "default_value": "latest",
-            "user_viewable": 1,
-            "user_editable": 1,
+            "user_viewable": true,
+            "user_editable": true,
             "rules": "required|string|max:20"
         }
     ]


### PR DESCRIPTION
Update wording to reference a modpack that works out the box as opposed to sevtech ages which doesn't work. I added my BOFA mods modpack however we can use any modpack that works out the box. If used, I vow to not break this modpack and will leave it in it's current state to guarantee it will work when people use it as a test.

### Changes to an existing Egg:

1. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [x] Have you tested your Egg changes?
