### PR TITLE
Update Curse Readme to reference working Modpack

### DIFF
--- a/minecraft/java/forge/curseforge-generic/README.md
+++ b/minecraft/java/forge/curseforge-generic/README.md
@@ -2,9 +2,9 @@
 
 ### This is a generic egg for curseforge modpacks
 
-You will need to give it a modpack ID. The ID for sevtech-ages is `268208` for example.  
+You will need to give it a modpack ID. The ID for BOFA mods is `375152` for example.  
 This can be found on the modpack page in the `About Project` section in the upper right corner.
 
-This will grabe the latest release when the version is set to latest. 
+This will grab the latest release when the version is set to latest. 
 
 It "should" grab versions of the pack based on the modpack version numbers


### PR DESCRIPTION
Updated Readme to include the Modpack that is referenced by default in the Curse Forge egg.

### All Submissions:

- [x] Have you followed the guidelines in our Contributing document?

- [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?