### PR TITLE
Update velocity egg image

### DIFF
--- a/minecraft/proxy/java/velocity/egg-velocity.json
+++ b/minecraft/proxy/java/velocity/egg-velocity.json
@@ -8,7 +8,7 @@
     "author": "parker@parkervcp.com",
     "description": "Velocity is a Minecraft server proxy with unparalleled server support, scalability, and flexibility.",
     "features": null,
-    "image": "quay.io\/parkervcp\/pterodactyl-images:adoptopenjdk-15-hotspot",
+    "image": "quay.io\/parkervcp\/pterodactyl-images:debian_openjdk-15-hotspot",
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -XX:+UseG1GC -XX:G1HeapRegionSize=4M -XX:+UnlockExperimentalVMOptions -XX:+ParallelRefProcEnabled -XX:+AlwaysPreTouch -XX:MaxInlineLevel=15 -jar {{SERVER_JARFILE}}",
     "config": {
         "files": "{\r\n    \"velocity.toml\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"bind = \": \"bind = \\\"0.0.0.0:{{server.build.default.port}}\\\"\"\r\n        }\r\n    }\r\n}",


### PR DESCRIPTION
resolves #867 
update the egg to use `debian_openjdk-15-hotspot` as the one it uses doesnt exist.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

### Changes to an existing Egg:

1. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [ ] Have you tested your Egg changes?
