### PR TITLE
pause_when_empty defaults to true.

### DIFF
--- a/steamcmd_servers/dont_starve/server.cluster.ini
+++ b/steamcmd_servers/dont_starve/server.cluster.ini
@@ -2,7 +2,7 @@
 game_mode = survival
 max_players = 10
 pvp = false
-pause_when_empty = false
+pause_when_empty = true
 
 [NETWORK]
 cluster_name = Pterodactyl Test Server


### PR DESCRIPTION
pause_when_empty should by default be true, it is the default and intended behavior for 99% of servers, along with that, most players(myself included), expect that default configs will match the standard default of the game, and this caught me off guard to see the game was still running.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
