### PR TITLE
PixArk - Fixes Servername

### DIFF
--- a/steamcmd_servers/pixark/egg-pix-a-r-k.json
+++ b/steamcmd_servers/pixark/egg-pix-a-r-k.json
@@ -1,15 +1,18 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
-        "version": "PTDL_v1"
+        "version": "PTDL_v1",
+        "update_url": null
     },
-    "exported_at": "2021-01-01T18:31:11+02:00",
+    "exported_at": "2021-01-01T19:35:46+01:00",
     "name": "PixARK",
     "author": "hello@venatus.digital",
     "description": "A simple Docker container with Wine to run PixARK using Pterodactyl Panel",
     "features": null,
-    "image": "quay.io\/parkervcp\/pterodactyl-images:ubuntu_wine-source",
-    "startup": "wine64 .\/ShooterGame\/Binaries\/Win64\/PixARKServer.exe CubeWorld_Light?listen?MaxPlayers={{MAX_PLAYERS}}?Port={{SERVER_PORT}}?QueryPort={{QPORT}}?RCONPort={{RCPORT}}?ServerPassword={{ARK_PASSWORD}}?ServerAdminPassword={{ARK_ADMIN_PASSWORD}}?CULTUREFORCOOKING=en -NoBattlEye -CubePort={{CUBEPORT}} -cubeworld=world -nosteamclient -NoHangDetection -game -server -log",
+    "images": [
+        "quay.io\/parkervcp\/pterodactyl-images:ubuntu_wine-source"
+    ],
+    "startup": "wine64 .\/ShooterGame\/Binaries\/Win64\/PixARKServer.exe CubeWorld_Light?listen?MaxPlayers={{MAX_PLAYERS}}?SessionName={{SRV_NAME}}?Port={{SERVER_PORT}}?QueryPort={{QPORT}}?RCONPort={{RCPORT}}?ServerPassword={{ARK_PASSWORD}}?ServerAdminPassword={{ARK_ADMIN_PASSWORD}}?CULTUREFORCOOKING=en -NoBattlEye -CubePort={{CUBEPORT}} -cubeworld=world -nosteamclient -NoHangDetection -game -server -log",
     "config": {
         "files": "{}",
         "startup": "{\r\n    \"done\": \"Full Startup:\",\r\n    \"userInteraction\": []\r\n}",
@@ -18,8 +21,8 @@
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/bash\r\n# PixARK: Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\napt -y update\r\napt -y --no-install-recommends --no-install-suggests install curl lib32gcc1 ca-certificates\r\n\r\n## just in case someone removed the defaults.\r\nif [ \"${STEAM_USER}\" == \"\" ]; then\r\n    STEAM_USER=anonymous\r\n    STEAM_PASS=\"\"\r\n    STEAM_AUTH=\"\"\r\nfi\r\n\r\n## download and install steamcmd\r\ncd \/tmp\r\nmkdir -p \/mnt\/server\/steamcmd\r\ncurl -sSL -o steamcmd.tar.gz https:\/\/steamcdn-a.akamaihd.net\/client\/installer\/steamcmd_linux.tar.gz\r\ntar -xzvf steamcmd.tar.gz -C \/mnt\/server\/steamcmd\r\ncd \/mnt\/server\/steamcmd\r\n\r\n# SteamCMD fails otherwise for some reason, even running as root.\r\n# This is changed at the end of the install process anyways.\r\nchown -R root:root \/mnt\r\nexport HOME=\/mnt\/server\r\n\r\n## install game using steamcmd\r\n.\/steamcmd.sh +@sSteamCmdForcePlatformType windows +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} +force_install_dir \/mnt\/server +app_update ${SRCDS_APPID} ${EXTRA_FLAGS} +quit",
-            "container": "ubuntu:latest",
+            "script": "#!\/bin\/bash\r\n# steamcmd Base Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\n# Image to install with is 'debian:buster-slim'\r\n\r\n##\r\n#\r\n# Variables\r\n# STEAM_USER, STEAM_PASS, STEAM_AUTH - Steam user setup. If a user has 2fa enabled it will most likely fail due to timeout. Leave blank for anon install.\r\n# WINDOWS_INSTALL - if it's a windows server you want to install set to 1\r\n# SRCDS_APPID - steam app id ffound here - https:\/\/developer.valvesoftware.com\/wiki\/Dedicated_Servers_List\r\n# EXTRA_FLAGS - when a server has extra glas for things like beta installs or updates.\r\n#\r\n##\r\n\r\napt -y update\r\napt -y --no-install-recommends install curl lib32gcc1 ca-certificates\r\n\r\n## just in case someone removed the defaults.\r\nif [ \"${STEAM_USER}\" == \"\" ]; then\r\n    echo -e \"steam user is not set.\\n\"\r\n    echo -e \"Using anonymous user.\\n\"\r\n    STEAM_USER=anonymous\r\n    STEAM_PASS=\"\"\r\n    STEAM_AUTH=\"\"\r\nelse\r\n    echo -e \"user set to ${STEAM_USER}\"\r\nfi\r\n\r\n## download and install steamcmd\r\ncd \/tmp\r\nmkdir -p \/mnt\/server\/steamcmd\r\ncurl -sSL -o steamcmd.tar.gz https:\/\/steamcdn-a.akamaihd.net\/client\/installer\/steamcmd_linux.tar.gz\r\ntar -xzvf steamcmd.tar.gz -C \/mnt\/server\/steamcmd\r\ncd \/mnt\/server\/steamcmd\r\n\r\n# SteamCMD fails otherwise for some reason, even running as root.\r\n# This is changed at the end of the install process anyways.\r\nchown -R root:root \/mnt\r\nexport HOME=\/mnt\/server\r\n\r\n## install game using steamcmd\r\n.\/steamcmd.sh +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} $( [[ \"${WINDOWS_INSTALL}\" == \"1\" ]] && printf %s '+@sSteamCmdForcePlatformType windows' ) +force_install_dir \/mnt\/server +app_update ${SRCDS_APPID} ${EXTRA_FLAGS} validate +quit ## other flags may be needed depending on install. looking at you cs 1.6\r\n\r\n## set up 32 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk32\r\ncp -v linux32\/steamclient.so ..\/.steam\/sdk32\/steamclient.so\r\n\r\n## set up 64 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk64\r\ncp -v linux64\/steamclient.so ..\/.steam\/sdk64\/steamclient.so",
+            "container": "debian:buster-slim",
             "entrypoint": "bash"
         }
     },
@@ -86,6 +89,24 @@
             "user_viewable": false,
             "user_editable": false,
             "rules": "required|numeric"
+        },
+        {
+            "name": "WINDOWS_INSTALL",
+            "description": "",
+            "env_variable": "WINDOWS_INSTALL",
+            "default_value": "1",
+            "user_viewable": false,
+            "user_editable": false,
+            "rules": "required|string|max:20"
+        },
+        {
+            "name": "Server Name",
+            "description": "Name of the Server !!!! NO SPACES ALLOWED !!!!",
+            "env_variable": "SRV_NAME",
+            "default_value": "PteroPixARKServer",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string|max:30"
         }
     ]
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [ ] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Server Submissions:

1. [ ] Does your submission pass tests (server is connectable)?
2. [ ] Does your server use a custom docker image?
    * [ ] Have you tried to use a generic image?
    * [ ] Did you PR the necessary changes to make it work?
3. [ ] Have you added the server to the main README.md?
4. [ ] Have you added a unique README.md for the server you are adding?

### Changes to an existing Egg:

1. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [x] Have you tested your Egg changes?


Changelog:

- Updated Image to the correct one and use new Egg Structure for Ptero 1.2.0
- Added Variable Server Name. Without Servername, it's a Pain to search for the Server in Console
- Switched SteamCMD Install to Parker's Installscript
- Switched Install Image to Debian Buster-Slim