### PR TITLE
Add multi-image selection to a bunch of eggs

### DIFF
--- a/bots/discord/discord.js/egg-discord-js-generic.json
+++ b/bots/discord/discord.js/egg-discord-js-generic.json
@@ -8,6 +8,11 @@
     "author": "parker@parkervcp.com",
     "description": "a generic discord js bot egg\r\n\r\nThis will clone a git repo for a bot. it defaults to master if no branch is specified.\r\n\r\nInstalls the node_modules on install. If you set user_upload then I assume you know what you are doing.",
     "image": "quay.io\/parkervcp\/pterodactyl-images:debian_nodejs-12",
+    "images": [
+        "quay.io\/parkervcp\/pterodactyl-images:debian_nodejs-10",
+        "quay.io\/parkervcp\/pterodactyl-images:debian_nodejs-12",
+        "quay.io\/parkervcp\/pterodactyl-images:debian_nodejs-14"
+    ],
     "startup": "if [[ -d .git ]] && [[ {{AUTO_UPDATE}} == \"1\" ]]; then git pull; fi; if [[ ! -z ${NODE_PACKAGES} ]]; then \/usr\/local\/bin\/npm install ${NODE_PACKAGES}; fi; if [ -f \/home\/container\/package.json ]; then  \/usr\/local\/bin\/npm install --production; fi; \/usr\/local\/bin\/node \/home\/container\/{{BOT_JS_FILE}}",
     "config": {
         "files": "{}",

--- a/bots/discord/discord.py/egg-discord-py-generic.json
+++ b/bots/discord/discord.py/egg-discord-py-generic.json
@@ -8,6 +8,10 @@
     "author": "parker@parkervcp.com",
     "description": "A Discord bot written in Python using discord.py\r\n\r\nhttps:\/\/github.com\/Ispira\/pixel-bot",
     "image": "quay.io\/parkervcp\/pterodactyl-images:debian_python-3.8",
+    "images": [
+        "quay.io\/parkervcp\/pterodactyl-images:debian_python-3.8",
+        "quay.io\/parkervcp\/pterodactyl-images:debian_python-2.7"
+    ],
     "startup": "if [[ -d .git ]] && [[ {{AUTO_UPDATE}} == \"1\" ]]; then git pull; fi; if [[ ! -z ${PY_PACKAGES} ]]; then pip install -U --target \/home\/container\/ ${PY_PACKAGES}; fi; if [[ -f \/home\/container\/requirements.txt ]]; then pip install -U --target \/home\/container\/ -r requirements.txt; fi; \/usr\/local\/bin\/python \/home\/container\/{{BOT_PY_FILE}}",
     "config": {
         "files": "{}",

--- a/minecraft/java/forge/curseforge-generic/egg-curseforge-generic.json
+++ b/minecraft/java/forge/curseforge-generic/egg-curseforge-generic.json
@@ -9,6 +9,10 @@
     "description": "A generic egg for a forge modpack",
     "features": null,
     "image": "quay.io\/pterodactyl\/core:java",
+    "images": [
+        "quay.io\/pterodactyl\/core:java",
+        "quay.io\/pterodactyl\/core:java-11"
+    ],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar server.jar",
     "config": {
         "files": "{\r\n    \"server.properties\": {\r\n        \"parser\": \"properties\",\r\n        \"find\": {\r\n            \"server-ip\": \"0.0.0.0\",\r\n            \"server-port\": \"{{server.build.default.port}}\",\r\n            \"query.port\": \"{{server.build.default.port}}\"\r\n        }\r\n    }\r\n}",

--- a/minecraft/java/forge/forge/egg-forge-enhanced.json
+++ b/minecraft/java/forge/forge/egg-forge-enhanced.json
@@ -9,6 +9,10 @@
     "description": "Minecraft Forge Server. Minecraft Forge is a modding API (Application Programming Interface), which makes it easier to create mods, and also make sure mods are compatible with each other.",
     "features": ["eula"],
     "image": "quay.io\/pterodactyl\/core:java",
+    "images": [
+        "quay.io\/pterodactyl\/core:java",
+        "quay.io\/pterodactyl\/core:java-11"
+    ],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",
     "config": {
         "files": "{\r\n    \"server.properties\": {\r\n        \"parser\": \"properties\",\r\n        \"find\": {\r\n            \"server-ip\": \"0.0.0.0\",\r\n            \"enable-query\": \"true\",\r\n            \"server-port\": \"{{server.build.default.port}}\",\r\n            \"query.port\": \"{{server.build.default.port}}\"\r\n        }\r\n    }\r\n}",

--- a/minecraft/java/ftb/egg-ftb-modpacksch-server.json
+++ b/minecraft/java/ftb/egg-ftb-modpacksch-server.json
@@ -8,6 +8,10 @@
     "author": "runemaster580@gmail.com",
     "description": "Since the release of the FTB APP, FTB modpacks are now distributed through modpacks.ch. This egg was developed for support for modpacks that are distributed through this.",
     "image": "quay.io\/pterodactyl\/core:java",
+    "images": [
+        "quay.io\/pterodactyl\/core:java",
+        "quay.io\/pterodactyl\/core:java-11"
+    ],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar forge-server.jar",
     "config": {
         "files": "{\r\n    \"server.properties\": {\r\n        \"parser\": \"properties\",\r\n        \"find\": {\r\n            \"server-ip\": \"0.0.0.0\",\r\n            \"enable-query\": \"true\",\r\n            \"server-port\": \"{{server.build.default.port}}\",\r\n            \"query.port\": \"{{server.build.default.port}}\"\r\n        }\r\n    }\r\n}",

--- a/minecraft/java/magma/egg-magma.json
+++ b/minecraft/java/magma/egg-magma.json
@@ -8,6 +8,10 @@
     "author": "support@pterodactyl.io",
     "description": "Magma is most powerful Forge server providing you with Forge mods and Bukkit Plugins using Spigot and Paper for Performance Optimization and Stability.",
     "image": "quay.io\/pterodactyl\/core:java",
+    "images": [
+        "quay.io\/pterodactyl\/core:java",
+        "quay.io\/pterodactyl\/core:java-11"
+    ],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",
     "config": {
         "files": "{\r\n    \"server.properties\": {\r\n        \"parser\": \"properties\",\r\n        \"find\": {\r\n            \"server-ip\": \"0.0.0.0\",\r\n            \"enable-query\": \"true\",\r\n            \"server-port\": \"{{server.build.default.port}}\"\r\n        }\r\n    }\r\n}",

--- a/minecraft/java/mohist/egg-mohist.json
+++ b/minecraft/java/mohist/egg-mohist.json
@@ -9,6 +9,10 @@
     "description": "Spigot fork with performance optimizations.",
     "features": null,
     "image": "quay.io\/pterodactyl\/core:java",
+    "images": [
+        "quay.io\/pterodactyl\/core:java",
+        "quay.io\/pterodactyl\/core:java-11"
+    ],
     "startup": "java -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}} pause",
     "config": {
         "files": "{\r\n    \"server.properties\": {\r\n        \"parser\": \"properties\",\r\n        \"find\": {\r\n            \"server-ip\": \"0.0.0.0\",\r\n            \"server-port\": \"{{server.build.default.port}}\"\r\n        }\r\n    }\r\n}",

--- a/minecraft/java/paper/egg-paper.json
+++ b/minecraft/java/paper/egg-paper.json
@@ -8,7 +8,11 @@
     "author": "parker@pterodactyl.io",
     "description": "High performance Spigot fork that aims to fix gameplay and mechanics inconsistencies.",
     "features": ["eula"],
-    "image": "quay.io\/parkervcp\/pterodactyl-images:debian_openjdk-11",
+    "image": "quay.io\/pterodactyl\/core:java-11",
+    "images": [
+        "quay.io\/pterodactyl\/core:java",
+        "quay.io\/pterodactyl\/core:java-11"
+    ],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",
     "config": {
         "files": "{\r\n    \"server.properties\": {\r\n        \"parser\": \"properties\",\r\n        \"find\": {\r\n            \"server-ip\": \"0.0.0.0\",\r\n            \"server-port\": \"{{server.build.default.port}}\"\r\n        }\r\n    }\r\n}",

--- a/minecraft/java/purpur/egg-purpur.json
+++ b/minecraft/java/purpur/egg-purpur.json
@@ -10,8 +10,11 @@
     "features": [
         "eula"
     ],
-    "image": "quay.io\/parkervcp\/pterodactyl-images:debian_openjdk-11",
-    "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",
+    "image": "quay.io\/pterodactyl\/core:java-11",
+    "images": [
+        "quay.io\/pterodactyl\/core:java",
+        "quay.io\/pterodactyl\/core:java-11"
+    ],    "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",
     "config": {
         "files": "{\r\n    \"server.properties\": {\r\n        \"parser\": \"properties\",\r\n        \"find\": {\r\n            \"server-ip\": \"0.0.0.0\",\r\n            \"server-port\": \"{{server.build.default.port}}\"\r\n        }\r\n    }\r\n}",
         "startup": "{\r\n    \"done\": \")! For help, type \",\r\n    \"userInteraction\": [\r\n        \"Go to eula.txt for more info.\"\r\n    ]\r\n}",

--- a/minecraft/java/purpur/egg-purpur.json
+++ b/minecraft/java/purpur/egg-purpur.json
@@ -14,7 +14,8 @@
     "images": [
         "quay.io\/pterodactyl\/core:java",
         "quay.io\/pterodactyl\/core:java-11"
-    ],    "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",
+    ],
+    "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",
     "config": {
         "files": "{\r\n    \"server.properties\": {\r\n        \"parser\": \"properties\",\r\n        \"find\": {\r\n            \"server-ip\": \"0.0.0.0\",\r\n            \"server-port\": \"{{server.build.default.port}}\"\r\n        }\r\n    }\r\n}",
         "startup": "{\r\n    \"done\": \")! For help, type \",\r\n    \"userInteraction\": [\r\n        \"Go to eula.txt for more info.\"\r\n    ]\r\n}",

--- a/minecraft/java/spigot/egg-spigot.json
+++ b/minecraft/java/spigot/egg-spigot.json
@@ -8,7 +8,11 @@
     "author": "support@pterodactyl.io",
     "description": "Spigot is the most widely-used modded Minecraft server software in the world. It powers many of the top Minecraft server networks around to ensure they can cope with their huge player base and ensure the satisfaction of their players. Spigot works by reducing and eliminating many causes of lag, as well as adding in handy features and settings that help make your job of server administration easier.",
     "features": ["eula"],
-    "image": "quay.io\/parkervcp\/pterodactyl-images:debian_openjdk-8-jre",
+    "image": "quay.io\/pterodactyl\/core:java-11",
+    "images": [
+        "quay.io\/pterodactyl\/core:java",
+        "quay.io\/pterodactyl\/core:java-11"
+    ],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",
     "config": {
         "files": "{\r\n    \"server.properties\": {\r\n        \"parser\": \"properties\",\r\n        \"find\": {\r\n            \"server-ip\": \"0.0.0.0\",\r\n            \"enable-query\": \"true\",\r\n            \"server-port\": \"{{server.build.default.port}}\",\r\n            \"query.port\": \"{{server.build.default.port}}\"\r\n        }\r\n    }\r\n}",

--- a/minecraft/java/spongeforge/egg-sponge-forge.json
+++ b/minecraft/java/spongeforge/egg-sponge-forge.json
@@ -9,6 +9,10 @@
     "description": "A community-driven open source Minecraft: Java Edition modding platform.",
     "features": ["eula"],
     "image": "quay.io\/pterodactyl\/core:java",
+    "images": [
+        "quay.io\/pterodactyl\/core:java",
+        "quay.io\/pterodactyl\/core:java-11"
+    ],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",
     "config": {
         "files": "{\r\n    \"server.properties\": {\r\n        \"parser\": \"properties\",\r\n        \"find\": {\r\n            \"server-ip\": \"0.0.0.0\",\r\n            \"server-port\": \"{{server.build.default.port}}\",\r\n            \"query.port\": \"{{server.build.default.port}}\"\r\n        }\r\n    }\r\n}",

--- a/minecraft/java/spongevanilla/egg-sponge-vanilla.json
+++ b/minecraft/java/spongevanilla/egg-sponge-vanilla.json
@@ -9,6 +9,10 @@
     "description": "SpongeVanilla is the implementation of the Sponge API on top of Vanilla Minecraft.",
     "features": ["eula"],
     "image": "quay.io\/pterodactyl\/core:java",
+    "images": [
+        "quay.io\/pterodactyl\/core:java",
+        "quay.io\/pterodactyl\/core:java-11"
+    ],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",
     "config": {
         "files": "{\r\n    \"server.properties\": {\r\n        \"parser\": \"properties\",\r\n        \"find\": {\r\n            \"server-ip\": \"0.0.0.0\",\r\n            \"server-port\": \"{{server.build.default.port}}\",\r\n            \"query.port\": \"{{server.build.default.port}}\"\r\n        }\r\n    }\r\n}",

--- a/minecraft/java/vanillacord/egg-vanilla-cord.json
+++ b/minecraft/java/vanillacord/egg-vanilla-cord.json
@@ -9,6 +9,10 @@
     "description": "Minecraft is a game about placing blocks and going on adventures. Explore randomly generated worlds and build amazing things from the simplest of homes to the grandest of castles. Play in Creative Mode with unlimited resources or mine deep in Survival Mode, crafting weapons and armor to fend off dangerous mobs. Do all this alone or with friends.\r\n\r\nVanillaCord adds support for BungeeCord's ip_forward setting.",
     "features": ["eula"],
     "image": "quay.io\/pterodactyl\/core:java",
+    "images": [
+        "quay.io\/pterodactyl\/core:java",
+        "quay.io\/pterodactyl\/core:java-11"
+    ],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",
     "config": {
         "files": "{\r\n    \"server.properties\": {\r\n        \"parser\": \"properties\",\r\n        \"find\": {\r\n            \"server-ip\": \"0.0.0.0\",\r\n            \"enable-query\": \"true\",\r\n            \"server-port\": \"{{server.build.default.port}}\",\r\n            \"query.port\": \"{{server.build.default.port}}\"\r\n        }\r\n    }\r\n}",

--- a/minecraft/proxy/cross_platform/waterdog/egg-waterdog.json
+++ b/minecraft/proxy/cross_platform/waterdog/egg-waterdog.json
@@ -9,6 +9,10 @@
     "description": "Waterdog is fork of the well-known Waterfall, which is a fork of the well-known BungeeCord, server teleportation suite.",
     "features": null,
     "image": "quay.io\/pterodactyl\/core:java",
+    "images": [
+        "quay.io\/pterodactyl\/core:java",
+        "quay.io\/pterodactyl\/core:java-11"
+    ],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",
     "config": {
         "files": "{}",

--- a/minecraft/proxy/java/travertine/egg-travertine.json
+++ b/minecraft/proxy/java/travertine/egg-travertine.json
@@ -11,7 +11,8 @@
     "image": "quay.io\/pterodactyl\/core:java-11",
     "images": [
         "quay.io\/pterodactyl\/core:java-11"
-    ],    "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",
+    ],
+    "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",
     "config": {
         "files": "{\r\n    \"config.yml\": {\r\n        \"parser\": \"yaml\",\r\n        \"find\": {\r\n            \"listeners[0].host\": \"0.0.0.0:{{server.build.default.port}}\",\r\n            \"servers.*.address\": {\r\n                \"127.0.0.1\": \"{{config.docker.interface}}\",\r\n                \"localhost\": \"{{config.docker.interface}}\"\r\n            }\r\n        }\r\n    }\r\n}",
         "startup": "{\r\n    \"done\": \"Listening on \",\r\n    \"userInteraction\": [\r\n        \"Listening on \/0.0.0.0:\"\r\n    ]\r\n}",

--- a/minecraft/proxy/java/travertine/egg-travertine.json
+++ b/minecraft/proxy/java/travertine/egg-travertine.json
@@ -8,8 +8,10 @@
     "author": "parker@parkervcp.com",
     "description": "Travertine is a fork of Waterfall with 1.7 protocol support. Waterfall is a fork of the well-known BungeeCord server teleportation suite.",
     "features": null,
-    "image": "quay.io\/parkervcp\/pterodactyl-images:debian_openjdk-11",
-    "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",
+    "image": "quay.io\/pterodactyl\/core:java-11",
+    "images": [
+        "quay.io\/pterodactyl\/core:java-11"
+    ],    "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",
     "config": {
         "files": "{\r\n    \"config.yml\": {\r\n        \"parser\": \"yaml\",\r\n        \"find\": {\r\n            \"listeners[0].host\": \"0.0.0.0:{{server.build.default.port}}\",\r\n            \"servers.*.address\": {\r\n                \"127.0.0.1\": \"{{config.docker.interface}}\",\r\n                \"localhost\": \"{{config.docker.interface}}\"\r\n            }\r\n        }\r\n    }\r\n}",
         "startup": "{\r\n    \"done\": \"Listening on \",\r\n    \"userInteraction\": [\r\n        \"Listening on \/0.0.0.0:\"\r\n    ]\r\n}",

--- a/minecraft/proxy/java/waterfall/egg-waterfall.json
+++ b/minecraft/proxy/java/waterfall/egg-waterfall.json
@@ -8,7 +8,11 @@
     "author": "hostmaster@waterfallgaming.net",
     "description": "Waterfall is a fork of the well-known BungeeCord server teleportation suite.",
     "features": null,
-    "image": "quay.io\/parkervcp\/pterodactyl-images:debian_openjdk-11",
+    "image": "quay.io\/pterodactyl\/core:java-11",
+    "images": [
+        "quay.io\/pterodactyl\/core:java",
+        "quay.io\/pterodactyl\/core:java-11"
+    ],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",
     "config": {
         "files": "{\r\n    \"config.yml\": {\r\n        \"parser\": \"yaml\",\r\n        \"find\": {\r\n            \"listeners[0].host\": \"0.0.0.0:{{server.build.default.port}}\",\r\n            \"servers.*.address\": {\r\n                \"127.0.0.1\": \"{{config.docker.interface}}\",\r\n                \"localhost\": \"{{config.docker.interface}}\"\r\n            }\r\n        }\r\n    }\r\n}",

--- a/stock-eggs/minecraft/egg-bungeecord.json
+++ b/stock-eggs/minecraft/egg-bungeecord.json
@@ -8,6 +8,10 @@
     "author": "support@pterodactyl.io",
     "description": "For a long time, Minecraft server owners have had a dream that encompasses a free, easy, and reliable way to connect multiple Minecraft servers together. BungeeCord is the answer to said dream. Whether you are a small server wishing to string multiple game-modes together, or the owner of the ShotBow Network, BungeeCord is the ideal solution for you. With the help of BungeeCord, you will be able to unlock your community's full potential.",
     "image": "quay.io\/pterodactyl\/core:java",
+    "images": [
+        "quay.io\/pterodactyl\/core:java",
+        "quay.io\/pterodactyl\/core:java-11"
+    ],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",
     "config": {
         "files": "{\r\n    \"config.yml\": {\r\n        \"parser\": \"yaml\",\r\n        \"find\": {\r\n            \"listeners[0].query_enabled\": true,\r\n            \"listeners[0].query_port\": \"{{server.build.default.port}}\",\r\n            \"listeners[0].host\": \"0.0.0.0:{{server.build.default.port}}\",\r\n            \"servers.*.address\": {\r\n                \"regex:^(127\\\\.0\\\\.0\\\\.1|localhost)(:\\\\d{1,5})?$\": \"{{config.docker.interface}}$2\"\r\n            }\r\n        }\r\n    }\r\n}",

--- a/stock-eggs/minecraft/egg-forge-minecraft.json
+++ b/stock-eggs/minecraft/egg-forge-minecraft.json
@@ -8,6 +8,10 @@
     "author": "support@pterodactyl.io",
     "description": "Minecraft Forge Server. Minecraft Forge is a modding API (Application Programming Interface), which makes it easier to create mods, and also make sure mods are compatible with each other.",
     "image": "quay.io\/pterodactyl\/core:java",
+    "images": [
+        "quay.io\/pterodactyl\/core:java",
+        "quay.io\/pterodactyl\/core:java-11"
+    ],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",
     "config": {
         "files": "{\r\n    \"server.properties\": {\r\n        \"parser\": \"properties\",\r\n        \"find\": {\r\n            \"server-ip\": \"0.0.0.0\",\r\n            \"enable-query\": \"true\",\r\n            \"server-port\": \"{{server.build.default.port}}\",\r\n            \"query.port\": \"{{server.build.default.port}}\"\r\n        }\r\n    }\r\n}",

--- a/stock-eggs/minecraft/egg-paper.json
+++ b/stock-eggs/minecraft/egg-paper.json
@@ -7,7 +7,11 @@
     "name": "Paper",
     "author": "parker@pterodactyl.io",
     "description": "High performance Spigot fork that aims to fix gameplay and mechanics inconsistencies.",
-    "image": "quay.io\/pterodactyl\/core:java",
+    "image": "quay.io\/pterodactyl\/core:java-11",
+    "images": [
+        "quay.io\/pterodactyl\/core:java",
+        "quay.io\/pterodactyl\/core:java-11"
+    ],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",
     "config": {
         "files": "{\r\n    \"server.properties\": {\r\n        \"parser\": \"properties\",\r\n        \"find\": {\r\n            \"server-ip\": \"0.0.0.0\",\r\n            \"server-port\": \"{{server.build.default.port}}\"\r\n        }\r\n    }\r\n}",

--- a/stock-eggs/minecraft/egg-vanilla-minecraft.json
+++ b/stock-eggs/minecraft/egg-vanilla-minecraft.json
@@ -8,6 +8,10 @@
     "author": "support@pterodactyl.io",
     "description": "Minecraft is a game about placing blocks and going on adventures. Explore randomly generated worlds and build amazing things from the simplest of homes to the grandest of castles. Play in Creative Mode with unlimited resources or mine deep in Survival Mode, crafting weapons and armor to fend off dangerous mobs. Do all this alone or with friends.",
     "image": "quay.io\/pterodactyl\/core:java",
+    "images": [
+        "quay.io\/pterodactyl\/core:java",
+        "quay.io\/pterodactyl\/core:java-11"
+    ],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",
     "config": {
         "files": "{\r\n    \"server.properties\": {\r\n        \"parser\": \"properties\",\r\n        \"find\": {\r\n            \"server-ip\": \"0.0.0.0\",\r\n            \"enable-query\": \"true\",\r\n            \"server-port\": \"{{server.build.default.port}}\"\r\n        }\r\n    }\r\n}",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

### Changes to an existing Egg:

1. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [ ] Have you tested your Egg changes?

Simply enough, adding multiple images to a bunch of eggs that can benefit from it while leaving `image` alone for older versions of the panel.

I'm not sure what image would be used as the default, though I think there really should be a way to set a default and alias for each image, so if I need to re-order something lmk.

Also switched some eggs from using parker's java 11 image to the official pterodactyl one, cause why not.

Not sure if I missed anything, and I have not tested them, as I don't have the time, though it looks right.