### PR TITLE
Add Factorio egg with factorio-mod-updater

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ If you are reading this it looks like you are looking to add an egg to your serv
 
 [ET Legacy](/enemy_territory/etlegacy)
 
-[Factorio](/factorio/factorio)
+[Factorio](/factorio)
+* [Vanilla](/factorio/factorio)
+* [ModUpdate](/factorio/factorio-modupdate)
 
 [Grand Theft Auto](/gta)
 * GTA V

--- a/factorio/README.md
+++ b/factorio/README.md
@@ -2,7 +2,7 @@
 
 #### The Factorio Server
 The server supports mods. 
-The factorio-modupdate eggs uses the factorio-mod-updater (https://github.com/pdemonaco/factorio-mod-updater) to update your mods when ReInstalling the Server.
+The factorio-modupdate egg uses the factorio-mod-updater (https://github.com/pdemonaco/factorio-mod-updater) to update your mods when ReInstalling the Server.
 
 #### from the developers
 

--- a/factorio/README.md
+++ b/factorio/README.md
@@ -1,7 +1,8 @@
 # Factorio
 
 #### The Factorio Server
-The server supports mods
+The server supports mods. 
+The factorio-modupdate eggs uses the factorio-mod-updater (https://github.com/pdemonaco/factorio-mod-updater) to update your mods when ReInstalling the Server.
 
 #### from the developers
 

--- a/factorio/factorio-modupdate/egg-factorio-modupdate.json
+++ b/factorio/factorio-modupdate/egg-factorio-modupdate.json
@@ -1,0 +1,121 @@
+{
+    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
+    "meta": {
+        "version": "PTDL_v1",
+        "update_url": null
+    },
+    "exported_at": "2021-01-15T16:32:57+01:00",
+    "name": "Factorio-ModUpdate",
+    "author": "tueye@tuworld.de",
+    "description": "The vanilla Factorio server. With automatic Mod Updates after ReInstall.\r\n\r\nhttps:\/\/www.factorio.com\/",
+    "features": null,
+    "images": [
+        "quay.io\/parkervcp\/pterodactyl-images:base_debian"
+    ],
+    "startup": ".\/bin\/x64\/factorio --port {{SERVER_PORT}} --server-settings data\/server-settings.json --start-server {{SAVE_NAME}}.zip",
+    "config": {
+        "files": "{\r\n    \"data\/server-settings.json\": {\r\n        \"parser\": \"json\",\r\n        \"find\": {\r\n            \"name\": \"{{server.build.env.SERVER_NAME}}\",\r\n            \"description\": \"{{server.build.env.SERVER_DESC}}\",\r\n            \"max_players\": \"{{server.build.env.MAX_SLOTS}}\",\r\n            \"username\": \"{{server.build.env.SERVER_USERNAME}}\",\r\n            \"token\": \"{{server.build.env.SERVER_TOKEN}}\",\r\n            \"autosave_interval\": \"{{server.build.env.SAVE_INTERVAL}}\",\r\n            \"autosave_slots\": \"{{server.build.env.SAVE_SLOTS}}\",\r\n            \"afk_autokick_interval\": \"{{server.build.env.AFK_KICK}}\"\r\n        }\r\n    }\r\n}",
+        "startup": "{\r\n    \"done\": \"Hosting game at\",\r\n    \"userInteraction\": []\r\n}",
+        "logs": "{\r\n    \"custom\": false,\r\n    \"location\": \"factorio-current.log\"\r\n}",
+        "stop": "\/quit"
+    },
+    "scripts": {
+        "installation": {
+            "script": "#!\/bin\/bash\r\n# Factorio Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\napt update \r\napt install -y curl tar xz-utils python3 python3-requests jq\r\n\r\nlatest_ModUpdate=$(curl --silent \"https:\/\/api.github.com\/repos\/pdemonaco\/factorio-mod-updater\/tags\" | jq -r '.[0].name')\r\n\r\nVERSION_JSON=$(curl -sSL https:\/\/factorio.com\/api\/latest-releases)\r\n\r\nlatest_stable=$(echo $VERSION_JSON | jq -r '.stable.headless')\r\nlatest_experimental=$(echo $VERSION_JSON | jq -r '.experimental.headless')\r\n\r\nif [ -z \"${FACTORIO_VERSION}\" ] || [ \"${FACTORIO_VERSION}\" == \"latest\" ]; then\r\n  DL_VERSION=$latest_stable\r\nelif [ \"${FACTORIO_VERSION}\" == \"experimental\" ]; then\r\n  DL_VERSION=$latest_experimental\r\nelse\r\n  DL_VERSION=${FACTORIO_VERSION}\r\nfi\r\n\r\nmkdir -p \/mnt\/server\r\ncd \/mnt\/server\r\n\r\necho -e \"\\n running 'curl -sL https:\/\/www.factorio.com\/get-download\/${DL_VERSION}\/headless\/linux64 -o factorio-${DL_VERSION}' \\n\"\r\n\r\ncurl -sL https:\/\/www.factorio.com\/get-download\/${DL_VERSION}\/headless\/linux64 -o factorio-${DL_VERSION}\r\n\r\ntar -xf factorio-${DL_VERSION} --strip-components=1 -C \/mnt\/server\r\n\r\nrm factorio-${DL_VERSION}\r\n\r\nif [ -e data\/map-gen-settings.json ]; then\r\n    echo \"map-gen exists\"\r\nelse\r\n    echo \"copying map-gen default settings\"\r\n    mv data\/map-gen-settings.example.json data\/map-gen-settings.json\r\nfi\r\n\r\nif [ -e data\/server-settings.json ]; then\r\n    echo \"server settings exists\"\r\nelse\r\n    echo \"copying server default settings\"\r\n    mv data\/server-settings.example.json data\/server-settings.json\r\nfi\r\n\r\nif [ -e map-settings.json ]; then\r\n    echo \"map settings exists\"\r\nelse\r\n    echo \"copying map default settings\"\r\n    mv data\/map-settings.example.json data\/map-settings.json\r\nfi\r\n\r\nif [ -e ${SAVE_NAME}.zip ]; then\r\n    echo \"save file exists\"\r\nelse\r\n    .\/bin\/x64\/factorio --create ${SAVE_NAME}\r\n    chmod o+w ${SAVE_NAME}.zip\r\nfi\r\n\r\n# Download Mod Updater\r\necho -e \"\\n running 'curl -sL https:\/\/github.com\/pdemonaco\/factorio-mod-updater\/archive\/${latest_ModUpdate}.tar.gz -o factorio-MU-${latest_ModUpdate}' \\n\"\r\n\r\ncurl -sL https:\/\/github.com\/pdemonaco\/factorio-mod-updater\/archive\/${latest_ModUpdate}.tar.gz -o factorio-MU-${latest_ModUpdate}\r\n\r\ntar -xf factorio-MU-${latest_ModUpdate} -C \/mnt\/server\r\n\r\nrm factorio-MU-${latest_ModUpdate}\r\n\r\n# Run Mod Updater\r\n.\/factorio-mod-updater-${latest_ModUpdate}\/mod_updater.py -s \/mnt\/server\/data\/server-settings.json -m \/mnt\/server\/mods --fact-path \/mnt\/server\/bin\/x64\/factorio --update",
+            "container": "debian:buster-slim",
+            "entrypoint": "bash"
+        }
+    },
+    "variables": [
+        {
+            "name": "Factorio Version",
+            "description": "Which version of Factorio to install and use.",
+            "env_variable": "FACTORIO_VERSION",
+            "default_value": "latest",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string|between:3,12"
+        },
+        {
+            "name": "Maximum Slots",
+            "description": "Total number of slots to allow on the server.",
+            "env_variable": "MAX_SLOTS",
+            "default_value": "20",
+            "user_viewable": true,
+            "user_editable": false,
+            "rules": "required|numeric|digits_between:1,3"
+        },
+        {
+            "name": "Save Name",
+            "description": "The save name for the server.",
+            "env_variable": "SAVE_NAME",
+            "default_value": "gamesave",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "alpha_dash|between:1,100"
+        },
+        {
+            "name": "Server Token",
+            "description": "Your factorio.com token, it is required for your server to be visible in the public server list.",
+            "env_variable": "SERVER_TOKEN",
+            "default_value": "undefined",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "alpha_num|max:100"
+        },
+        {
+            "name": "Server Name",
+            "description": "Name of the game as it will appear in the game listing",
+            "env_variable": "SERVER_NAME",
+            "default_value": "Factorio Server",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string|max:100"
+        },
+        {
+            "name": "Server Description",
+            "description": "Description of the game that will appear in the listing.",
+            "env_variable": "SERVER_DESC",
+            "default_value": "Description",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string|max:200"
+        },
+        {
+            "name": "Server Username",
+            "description": "Username used for the server",
+            "env_variable": "SERVER_USERNAME",
+            "default_value": "unnamed",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string|max:40"
+        },
+        {
+            "name": "Auto Save Interval",
+            "description": "Time between auto saves specified in minutes",
+            "env_variable": "SAVE_INTERVAL",
+            "default_value": "10",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|numeric|digits_between:1,3"
+        },
+        {
+            "name": "Auto Save Slots",
+            "description": "The number of auto saves to keep.",
+            "env_variable": "SAVE_SLOTS",
+            "default_value": "5",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|numeric|digits_between:1,3"
+        },
+        {
+            "name": "AFK Kick",
+            "description": "Time specified in minutes to kick AFK players.\r\n0 is off",
+            "env_variable": "AFK_KICK",
+            "default_value": "0",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|numeric|digits_between:1,3"
+        }
+    ]
+}


### PR DESCRIPTION
Added Update feature to automatically update Factorio Mods to latest compatible Version. Uses factorio-mod-updater from https://github.com/pdemonaco/factorio-mod-updater

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Did you branch your changes and PR from that branch and not from your master branch?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Server Submissions:

1. [x] Does your submission pass tests (server is connectable)?
2. [x] Have you added the server to the main README.md?
3. [ ] Have you added a unique README.md for the server you are adding?
   No. I Added an additional entry in the existing README.md

### Changes to an existing Egg:

1. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [x] Have you tested your Egg changes?
