### PR TITLE
Magma download fix

### DIFF
--- a/minecraft/java/magma/egg-magma.json
+++ b/minecraft/java/magma/egg-magma.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v1",
         "update_url": null
     },
-    "exported_at": "2021-01-24T10:08:35-08:00",
+    "exported_at": "2021-01-25T03:08:06-08:00",
     "name": "Magma",
     "author": "support@pterodactyl.io",
     "description": "Magma is most powerful Forge server providing you with Forge mods and Bukkit Plugins using Spigot and Paper for Performance Optimization and Stability.",
@@ -23,7 +23,7 @@
     },
     "scripts": {
         "installation": {
-            "script": "apt update\r\napt install -y curl\r\n\r\nif [ ! -d \/mnt\/server\/ ]; then\r\n    mkdir \/mnt\/server\r\nfi\r\n\r\ncd \/mnt\/server\/\r\n\r\n## get latest download link\r\necho -e \"Set to download the ${BUILD} build\"\r\nif [ \"${BUILD}\" == \"dev\" ]; then\r\n    echo -e \"dev tag is ${tag}\"\r\nfi\r\n\r\nif [ \"${VANILLA_VERSION}\" == \"1.12\" ]; then\r\n    if [ ! -z ${BUILD_NUMBER} ]; then\r\n        DOWNLOAD_LINK=https:\/\/ci.hexeption.dev\/job\/Magma%20Foundation\/job\/Magma\/job\/master\/${BUILD_NUMBER}\/artifact\/\r\n    else\r\n        DOWNLOAD_LINK=https:\/\/ci.hexeption.dev\/job\/Magma%20Foundation\/job\/Magma\/job\/master\/lastSuccessfulBuild\/artifact\/\r\n    fi\r\nfi\r\n\r\nif [ \"${VANILLA_VERSION}\" == \"1.15\" ]; then\r\n    if [ ! -z ${BUILD_NUMBER} ]; then\r\n        DOWNLOAD_LINK=https:\/\/ci.hexeption.dev\/job\/Magma%20Foundation\/job\/Magma-1.15.x\/job\/1.15.x\/${BUILD_NUMBER}\/artifact\/\r\n    else\r\n        DOWNLOAD_LINK=https:\/\/ci.hexeption.dev\/job\/Magma%20Foundation\/job\/Magma-1.15.x\/job\/1.15.x\/lastSuccessfulBuild\/artifact\/\r\n    fi\r\nfi\r\n\r\necho -e \"Download URL is ${DOWNLOAD_LINK}\"\r\n\r\n## validate download link\r\nif [ ! -z \"${DOWNLOAD_LINK}\" ] ; then \r\n    if curl --output \/dev\/null --silent --head --fail ${DOWNLOAD_LINK}; then\r\n        echo -e \"link is valid. setting download link to ${DOWNLOAD_LINK}\"\r\n        DOWNLOAD_LINK=${DOWNLOAD_LINK}\r\n    else        \r\n        echo -e \"link is invalid closing out\"\r\n        exit 2\r\n    fi\r\nfi\r\n\r\n## mv old server files\r\nif [ -f ${SERVER_JARFILE} ]; then\r\n    echo -e \"moving old server.jar\"\r\n    mv ${SERVER_JARFILE} ${SERVER_JARFILE}.old\r\nfi\r\n\r\n## download files\r\necho -e \"running: curl -sSL -o ${SERVER_JARFILE} ${DOWNLOAD_LINK}\"\r\ncurl -s -o ${SERVER_JARFILE} -sSL ${DOWNLOAD_LINK}\r\n\r\n#Checking if downloaded jars exist\r\nif [ ! -f .\/server.jar ]; then\r\n    echo \"!!! Error downloading build version ${BUILD_VERSION} !!!\"\r\n    exit\r\nfi\r\n\r\necho -e \"Install Complete\"",
+            "script": "apt update\r\napt install -y curl\r\n\r\nif [ ! -d \/mnt\/server\/ ]; then\r\n    mkdir \/mnt\/server\r\nfi\r\n\r\ncd \/mnt\/server\/\r\n\r\nif [ ! -z ${MC_VERSION} ]; then\r\n    DOWNLOAD_LINK=https:\/\/api.magmafoundation.org\/api\/resources\/magma\/${MC_VERSION}\/dev\/latest\/download\r\nelse\r\n    DOWNLOAD_LINK=https:\/\/api.magmafoundation.org\/api\/resources\/magma\/1.12.2\/dev\/latest\/download\r\nfi\r\n\r\necho -e \"Download URL is ${DOWNLOAD_LINK}\"\r\n\r\n## validate download link\r\nif [ ! -z \"${DOWNLOAD_LINK}\" ] ; then \r\n    if curl --output \/dev\/null --silent --head --fail ${DOWNLOAD_LINK}; then\r\n        echo -e \"link is valid. setting download link to ${DOWNLOAD_LINK}\"\r\n        DOWNLOAD_LINK=${DOWNLOAD_LINK}\r\n    else        \r\n        echo -e \"link is invalid closing out\"\r\n        exit 2\r\n    fi\r\nfi\r\n\r\n## mv old server files\r\nif [ -f ${SERVER_JARFILE} ]; then\r\n    echo -e \"moving old server.jar\"\r\n    mv ${SERVER_JARFILE} ${SERVER_JARFILE}.old\r\nfi\r\n\r\n## download files\r\necho -e \"running: curl -sSL -o ${SERVER_JARFILE} ${DOWNLOAD_LINK}\"\r\ncurl -s -o ${SERVER_JARFILE} -sSL ${DOWNLOAD_LINK}\r\n\r\necho -e \"Install Complete\"",
             "container": "debian:buster-slim",
             "entrypoint": "bash"
         }
@@ -39,27 +39,9 @@
             "rules": "required|regex:\/^([\\w\\d._-]+)(\\.jar)$\/"
         },
         {
-            "name": "Server Version",
-            "description": "The version of Minecraft to install.\r\n\r\nOnly versions supported are 1.12 and 1.15.",
-            "env_variable": "VANILLA_VERSION",
-            "default_value": "1.12",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": "required|string|between:3,15"
-        },
-        {
-            "name": "Magma Version",
-            "description": "The Magma version to download.\r\n\r\nValid types: latest",
-            "env_variable": "VERSION",
-            "default_value": "latest",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": "required|string|max:20"
-        },
-        {
-            "name": "Build Number",
-            "description": "Optional. Specify build number. Overrides Version.",
-            "env_variable": "BUILD_NUMBER",
+            "name": "Minecraft Version",
+            "description": "Optional.\r\n\r\nSpecify vanilla version other than default 1.12.2.",
+            "env_variable": "MC_VERSION",
             "default_value": "",
             "user_viewable": true,
             "user_editable": true,

--- a/minecraft/java/magma/egg-magma.json
+++ b/minecraft/java/magma/egg-magma.json
@@ -1,17 +1,19 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
-        "version": "PTDL_v1"
+        "version": "PTDL_v1",
+        "update_url": null
     },
-    "exported_at": "2020-03-28T14:53:55-04:00",
+    "exported_at": "2021-01-24T10:08:35-08:00",
     "name": "Magma",
     "author": "support@pterodactyl.io",
     "description": "Magma is most powerful Forge server providing you with Forge mods and Bukkit Plugins using Spigot and Paper for Performance Optimization and Stability.",
-    "image": "quay.io\/pterodactyl\/core:java",
+    "features": null,
     "images": [
         "quay.io\/pterodactyl\/core:java",
         "quay.io\/pterodactyl\/core:java-11"
     ],
+    "file_denylist": "",
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",
     "config": {
         "files": "{\r\n    \"server.properties\": {\r\n        \"parser\": \"properties\",\r\n        \"find\": {\r\n            \"server-ip\": \"0.0.0.0\",\r\n            \"enable-query\": \"true\",\r\n            \"server-port\": \"{{server.build.default.port}}\"\r\n        }\r\n    }\r\n}",
@@ -21,9 +23,9 @@
     },
     "scripts": {
         "installation": {
-            "script": "## this is a simple script to use the github API for release versions.\r\n## this requires the egg has a variable for GITHUB_PACKAGE, VERSION and MATCH (match is to match the filename in some way)\r\n## this supports using oauth\/personal access tokens via GITHUB_USER and GITHUB_OAUTH_TOKEN (both are required.)\r\n## if you are getting hit with GitHub API limit issues then you need to have the user and token set.\r\n\r\napk add --no-cache curl\r\n\r\nif [ ! -d \/mnt\/server\/ ]; then\r\n    mkdir \/mnt\/server\r\nfi\r\n\r\ncd \/mnt\/server\/\r\n\r\n## get latest download link\r\necho -e \"Set to download the ${BUILD} build\"\r\nif [ \"${BUILD}\" == \"dev\" ]; then\r\n    echo -e \"dev tag is ${tag}\"\r\nfi\r\n\r\ncase ${BUILD} in\r\n\r\n  \"recommended\" | \"stable\" | \"latest\")\r\n    DOWNLOAD_URL=\"https:\/\/api.magmafoundation.org\/api\/resources\/magma\/${VANILLA_VERSION}\/stable\/latest\/download\"\r\n    ;;\r\n\r\n  \"dev\")\r\n    DOWNLOAD_URL=\"https:\/\/api.magmafoundation.org\/api\/resources\/magma\/${VANILLA_VERSION}\/dev\/${TAG}\/download\"\r\n    ;;\r\n\r\n  *)\r\n    DOWNLOAD_URL=\"https:\/\/api.magmafoundation.org\/api\/resources\/magma\/${VANILLA_VERSION}\/stable\/latest\/download\"\r\n    ;;\r\nesac\r\n\r\necho -e \"Download URL is ${DOWNLOAD_URL}\"\r\n\r\n## validate download link\r\nif [ ! -z \"${DOWNLOAD_URL}\" ] ; then \r\n    if curl --output \/dev\/null --silent --head --fail ${DOWNLOAD_URL}; then\r\n        echo -e \"link is valid. setting download link to ${DOWNLOAD_URL}\"\r\n        DOWNLOAD_LINK=${DOWNLOAD_URL}\r\n    else        \r\n        echo -e \"link is invalid closing out\"\r\n        exit 2\r\n    fi\r\nfi\r\n\r\n# Adding '.jar' if it isn't part of the file name\r\nif [[ ${SERVER_JARFILE} == *\\.jar ]]; then\r\n    echo -e \"adding.jar to server file name\"\r\n    SERVER_JARFILE=\"${SERVER_JARFILE}.jar\"\r\nfi\r\n\r\n## mv old server files\r\nif [ -f ${SERVER_JARFILE} ]; then\r\n    echo -e \"moving old server.jar\"\r\n    mv ${SERVER_JARFILE} ${SERVER_JARFILE}.old\r\nfi\r\n\r\n## download files\r\necho -e \"running: curl -sSL -o ${SERVER_JARFILE} ${DOWNLOAD_LINK}\"\r\ncurl -sSL -o ${SERVER_JARFILE} ${DOWNLOAD_LINK}\r\n\r\necho -e \"Install Complete\"",
-            "container": "alpine:3.10",
-            "entrypoint": "ash"
+            "script": "apt update\r\napt install -y curl\r\n\r\nif [ ! -d \/mnt\/server\/ ]; then\r\n    mkdir \/mnt\/server\r\nfi\r\n\r\ncd \/mnt\/server\/\r\n\r\n## get latest download link\r\necho -e \"Set to download the ${BUILD} build\"\r\nif [ \"${BUILD}\" == \"dev\" ]; then\r\n    echo -e \"dev tag is ${tag}\"\r\nfi\r\n\r\nif [ \"${VANILLA_VERSION}\" == \"1.12\" ]; then\r\n    if [ ! -z ${BUILD_NUMBER} ]; then\r\n        DOWNLOAD_LINK=https:\/\/ci.hexeption.dev\/job\/Magma%20Foundation\/job\/Magma\/job\/master\/${BUILD_NUMBER}\/artifact\/\r\n    else\r\n        DOWNLOAD_LINK=https:\/\/ci.hexeption.dev\/job\/Magma%20Foundation\/job\/Magma\/job\/master\/lastSuccessfulBuild\/artifact\/\r\n    fi\r\nfi\r\n\r\nif [ \"${VANILLA_VERSION}\" == \"1.15\" ]; then\r\n    if [ ! -z ${BUILD_NUMBER} ]; then\r\n        DOWNLOAD_LINK=https:\/\/ci.hexeption.dev\/job\/Magma%20Foundation\/job\/Magma-1.15.x\/job\/1.15.x\/${BUILD_NUMBER}\/artifact\/\r\n    else\r\n        DOWNLOAD_LINK=https:\/\/ci.hexeption.dev\/job\/Magma%20Foundation\/job\/Magma-1.15.x\/job\/1.15.x\/lastSuccessfulBuild\/artifact\/\r\n    fi\r\nfi\r\n\r\necho -e \"Download URL is ${DOWNLOAD_LINK}\"\r\n\r\n## validate download link\r\nif [ ! -z \"${DOWNLOAD_LINK}\" ] ; then \r\n    if curl --output \/dev\/null --silent --head --fail ${DOWNLOAD_LINK}; then\r\n        echo -e \"link is valid. setting download link to ${DOWNLOAD_LINK}\"\r\n        DOWNLOAD_LINK=${DOWNLOAD_LINK}\r\n    else        \r\n        echo -e \"link is invalid closing out\"\r\n        exit 2\r\n    fi\r\nfi\r\n\r\n## mv old server files\r\nif [ -f ${SERVER_JARFILE} ]; then\r\n    echo -e \"moving old server.jar\"\r\n    mv ${SERVER_JARFILE} ${SERVER_JARFILE}.old\r\nfi\r\n\r\n## download files\r\necho -e \"running: curl -sSL -o ${SERVER_JARFILE} ${DOWNLOAD_LINK}\"\r\ncurl -s -o ${SERVER_JARFILE} -sSL ${DOWNLOAD_LINK}\r\n\r\n#Checking if downloaded jars exist\r\nif [ ! -f .\/server.jar ]; then\r\n    echo \"!!! Error downloading build version ${BUILD_VERSION} !!!\"\r\n    exit\r\nfi\r\n\r\necho -e \"Install Complete\"",
+            "container": "debian:buster-slim",
+            "entrypoint": "bash"
         }
     },
     "variables": [
@@ -32,36 +34,36 @@
             "description": "The name of the server jarfile to run the server with.",
             "env_variable": "SERVER_JARFILE",
             "default_value": "server.jar",
-            "user_viewable": 1,
-            "user_editable": 1,
+            "user_viewable": false,
+            "user_editable": false,
             "rules": "required|regex:\/^([\\w\\d._-]+)(\\.jar)$\/"
         },
         {
             "name": "Server Version",
-            "description": "The version of Minecraft Vanilla to install.\r\n\r\nOnly version currently supported is 1.12.2 as that is all there are builds for.",
+            "description": "The version of Minecraft to install.\r\n\r\nOnly versions supported are 1.12 and 1.15.",
             "env_variable": "VANILLA_VERSION",
-            "default_value": "1.12.2",
-            "user_viewable": 1,
-            "user_editable": 1,
+            "default_value": "1.12",
+            "user_viewable": true,
+            "user_editable": true,
             "rules": "required|string|between:3,15"
         },
         {
-            "name": "Magma Build",
-            "description": "What version of magma to download.\r\n\r\nrecommended, stable, latest = current stable\r\ndev = latest dev build",
-            "env_variable": "BUILD",
+            "name": "Magma Version",
+            "description": "The Magma version to download.\r\n\r\nValid types: latest",
+            "env_variable": "VERSION",
             "default_value": "latest",
-            "user_viewable": 1,
-            "user_editable": 1,
+            "user_viewable": true,
+            "user_editable": true,
             "rules": "required|string|max:20"
         },
         {
-            "name": "Magma Dev Tag",
-            "description": "The dev tagged version to download. default is latest.",
-            "env_variable": "TAG",
-            "default_value": "latest",
-            "user_viewable": 1,
-            "user_editable": 1,
-            "rules": "required|string|max:20"
+            "name": "Build Number",
+            "description": "Optional. Specify build number. Overrides Version.",
+            "env_variable": "BUILD_NUMBER",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "nullable|string|max:20"
         }
     ]
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to an existing Egg:

1. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [x] Have you tested your Egg changes?

Updates the download links. Stable tag appears to be deprecated, resulting in an internal error. Dev is the only working endpoint for the moment. Left the version variable for when future versions of 1.15.x and 1.16.x are published. Closes #941 
