### PR TITLE
RedBot - Fix owner ID on team applications

### DIFF
--- a/bots/discord/redbot/egg-red.json
+++ b/bots/discord/redbot/egg-red.json
@@ -1,14 +1,18 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
-        "version": "PTDL_v1"
+        "version": "PTDL_v1",
+        "update_url": null
     },
-    "exported_at": "2020-04-20T23:06:14-04:00",
-    "name": "Red",
+    "exported_at": "2021-01-27T03:17:15-05:00",
+    "name": "RedBot",
     "author": "parker@parkervcp.com",
     "description": "A multifunction Discord bot \r\n\r\nhttps:\/\/github.com\/Cog-Creators\/Red-DiscordBot",
-    "image": "quay.io\/parkervcp\/pterodactyl-images:bot_red",
-    "startup": "PATH=$PATH:\/home\/container\/.local\/bin redbot pterodactyl --token {{TOKEN}} --prefix {{PREFIX}}",
+    "features": null,
+    "images": [
+        "quay.io\/parkervcp\/pterodactyl-images:bot_red"
+    ],
+    "startup": "PATH=$PATH:\/home\/container\/.local\/bin redbot pterodactyl --token {{TOKEN}} --prefix {{PREFIX}} --owner {{OWNERID}}",
     "config": {
         "files": "{}",
         "startup": "{\r\n    \"done\": \"Invite URL:\"\r\n}",
@@ -28,8 +32,8 @@
             "description": "Get your own token here - https:\/\/discordapp.com\/developers\/applications\/",
             "env_variable": "TOKEN",
             "default_value": "GET_YOUR_OWN",
-            "user_viewable": 1,
-            "user_editable": 1,
+            "user_viewable": true,
+            "user_editable": true,
             "rules": "required|string"
         },
         {
@@ -37,8 +41,17 @@
             "description": "The prefix for commands from the bot.",
             "env_variable": "PREFIX",
             "default_value": ".",
-            "user_viewable": 1,
-            "user_editable": 1,
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string"
+        },
+        {
+            "name": "Owner ID",
+            "description": "The Discord User ID of the owner of this bot.",
+            "env_variable": "OWNERID",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
             "rules": "required|string"
         }
     ]

--- a/bots/discord/redbot/egg-red.json
+++ b/bots/discord/redbot/egg-red.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v1",
         "update_url": null
     },
-    "exported_at": "2021-01-27T03:17:15-05:00",
+    "exported_at": "2021-01-29T15:09:04-05:00",
     "name": "RedBot",
     "author": "parker@parkervcp.com",
     "description": "A multifunction Discord bot \r\n\r\nhttps:\/\/github.com\/Cog-Creators\/Red-DiscordBot",
@@ -52,7 +52,7 @@
             "default_value": "",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string"
+            "rules": "nullable|integer"
         }
     ]
 }


### PR DESCRIPTION
This change fixes an issue where RedBot could not automatically select an owner if the bot was on a Team Applications account on the Discord developers website. Manually passing the user ID of the owner as a console argument fixes this issue.

All changes made in this PR:
- Added a new user changable variable to set the owner ID
- Changed the startup command to include the owner ID variable

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

### Changes to an existing Egg:

1. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [x] Have you tested your Egg changes?
