### PR TITLE
Fix Eco start done config

### DIFF
--- a/steamcmd_servers/eco/egg-eco.json
+++ b/steamcmd_servers/eco/egg-eco.json
@@ -3,7 +3,7 @@
     "meta": {
         "version": "PTDL_v1"
     },
-    "exported_at": "2021-02-07T19:56:46-06:00",
+    "exported_at": "2021-02-08T10:56:34-06:00",
     "name": "Eco",
     "author": "info@goover.de",
     "description": "Eco is an online world from Strange Loop Games where players must build civilization using resources from an ecosystem that can be damaged and destroyed. The world of Eco is an incredibly reactive one, and whatever any player does in the world affects the underlying ecosystem.",
@@ -12,7 +12,7 @@
     "startup": "export DOTNET_BUNDLE_EXTRACT_BASE_DIR=.\/dotnet-bundle &&  .\/EcoServer",
     "config": {
         "files": "{\r\n    \"Configs\/Network.eco\": {\r\n        \"parser\": \"json\",\r\n        \"find\": {\r\n            \"GameServerPort\": \"{{server.build.default.port}}\",\r\n            \"WebServerPort\": \"{{server.build.env.WEB_PORT}}\",\r\n            \"PublicServer\": \"{{server.build.env.PUB_SRV}}\",\r\n            \"Password\": \"{{server.build.env.SRV_PWD}}\",\r\n            \"UPnPEnabled\": \"{{server.build.env.UPNP}}\",\r\n            \"Description\": \"{{server.build.env.SRV_DES}}\"\r\n        }\r\n    }\r\n}",
-        "startup": "{\r\n    \"done\": \"[Server Initialization]... Finished in\",\r\n    \"userInteraction\": []\r\n}",
+        "startup": "{\r\n    \"done\": \"Web Server now listening on\",\r\n    \"userInteraction\": []\r\n}",
         "logs": "{\r\n    \"custom\": true,\r\n    \"location\": \"logs\/latest.log\"\r\n}",
         "stop": "exit"
     },

--- a/steamcmd_servers/eco/egg-eco.json
+++ b/steamcmd_servers/eco/egg-eco.json
@@ -3,7 +3,7 @@
     "meta": {
         "version": "PTDL_v1"
     },
-    "exported_at": "2020-11-30T16:56:23+01:00",
+    "exported_at": "2021-02-07T19:56:46-06:00",
     "name": "Eco",
     "author": "info@goover.de",
     "description": "Eco is an online world from Strange Loop Games where players must build civilization using resources from an ecosystem that can be damaged and destroyed. The world of Eco is an incredibly reactive one, and whatever any player does in the world affects the underlying ecosystem.",
@@ -12,7 +12,7 @@
     "startup": "export DOTNET_BUNDLE_EXTRACT_BASE_DIR=.\/dotnet-bundle &&  .\/EcoServer",
     "config": {
         "files": "{\r\n    \"Configs\/Network.eco\": {\r\n        \"parser\": \"json\",\r\n        \"find\": {\r\n            \"GameServerPort\": \"{{server.build.default.port}}\",\r\n            \"WebServerPort\": \"{{server.build.env.WEB_PORT}}\",\r\n            \"PublicServer\": \"{{server.build.env.PUB_SRV}}\",\r\n            \"Password\": \"{{server.build.env.SRV_PWD}}\",\r\n            \"UPnPEnabled\": \"{{server.build.env.UPNP}}\",\r\n            \"Description\": \"{{server.build.env.SRV_DES}}\"\r\n        }\r\n    }\r\n}",
-        "startup": "{\r\n    \"done\": \"[Server Initialization]... \",\r\n    \"userInteraction\": []\r\n}",
+        "startup": "{\r\n    \"done\": \"[Server Initialization]... Finished in\",\r\n    \"userInteraction\": []\r\n}",
         "logs": "{\r\n    \"custom\": true,\r\n    \"location\": \"logs\/latest.log\"\r\n}",
         "stop": "exit"
     },


### PR DESCRIPTION
The server is outputting `[Server Initialization]...` when it first starts and not when it finishes starting. Fix server startup done config by adding `Finished in`.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Did you branch your changes and PR from that branch and not from your master branch?

### Changes to an existing Egg:

1. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [x] Have you tested your Egg changes?
