### PR TITLE
Add client port parameter to Garry's Mod server

### DIFF
--- a/stock-eggs/source-engine/README.md
+++ b/stock-eggs/source-engine/README.md
@@ -50,6 +50,7 @@ Garry's Mod is a physics sandbox. There aren't any predefined aims or goals. We 
 |   Port   | default |
 |----------|---------|
 |   Game   | 27015   |
+|   Game   | 27005   |
 
 ## Insurgency
 

--- a/stock-eggs/source-engine/egg-garrys-mod.json
+++ b/stock-eggs/source-engine/egg-garrys-mod.json
@@ -8,7 +8,7 @@
     "author": "support@pterodactyl.io",
     "description": "Garrys Mod, is a sandbox physics game created by Garry Newman, and developed by his company, Facepunch Studios.",
     "image": "quay.io\/pterodactyl\/core:source",
-    "startup": ".\/srcds_run -game garrysmod -console -port {{SERVER_PORT}} +ip 0.0.0.0 +host_workshop_collection {{WORKSHOP_ID}} +map {{SRCDS_MAP}} +gamemode {{GAMEMODE}} -strictportbind -norestart +sv_setsteamaccount {{STEAM_ACC}} +maxplayers {{MAX_PLAYERS}}  -tickrate {{TICKRATE}}",
+    "startup": ".\/srcds_run -game garrysmod -console -port {{SERVER_PORT}} +clientport {{CLIENT_PORT}} +ip 0.0.0.0 +host_workshop_collection {{WORKSHOP_ID}} +map {{SRCDS_MAP}} +gamemode {{GAMEMODE}} -strictportbind -norestart +sv_setsteamaccount {{STEAM_ACC}} +maxplayers {{MAX_PLAYERS}}  -tickrate {{TICKRATE}}",
     "config": {
         "files": "{}",
         "startup": "{\r\n    \"done\": \"gameserver Steam ID\",\r\n    \"userInteraction\": []\r\n}",
@@ -85,6 +85,15 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|integer|max:100"
+        },
+        {
+            "name": "Client Port",
+            "description": "The port used for clients. (Must be different from server port!)",
+            "env_variable": "CLIENT_PORT",
+            "default_value": "27005",
+            "user_viewable": false,
+            "user_editable": false,
+            "rules": "required|integer"
         }
     ]
 }

--- a/stock-eggs/source-engine/egg-garrys-mod.json
+++ b/stock-eggs/source-engine/egg-garrys-mod.json
@@ -3,7 +3,7 @@
     "meta": {
         "version": "PTDL_v1"
     },
-    "exported_at": "2020-10-19T23:34:44+00:00",
+    "exported_at": "2021-02-08T15:01:46+01:00",
     "name": "Garrys Mod",
     "author": "support@pterodactyl.io",
     "description": "Garrys Mod, is a sandbox physics game created by Garry Newman, and developed by his company, Facepunch Studios.",


### PR DESCRIPTION
This PR adds a client port variable to the garry's mod egg. This is usefull if you want to have multiple servers with the same ip but different ports.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Did you branch your changes and PR from that branch and not from your master branch?


### Changes to an existing Egg:

1. [X] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [X] Have you tested your Egg changes?
