### PR TITLE
Add min rule to server password

### DIFF
--- a/steamcmd_servers/valheim/egg-valheim.json
+++ b/steamcmd_servers/valheim/egg-valheim.json
@@ -41,7 +41,7 @@
             "default_value": "secret",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string|max:20"
+            "rules": "required|string|min:5|max:20"
         },
         {
             "name": "World Name",


### PR DESCRIPTION
I had the problem that my server crashed with a 3 digit password. After some google I found this:  https://github.com/GameServerManagers/LinuxGSM/issues/3229

Changing to a 5 digit password solved the problem. So to prevent this crash this PR adds a min rule to the password variable.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Did you branch your changes and PR from that branch and not from your master branch?

### Changes to an existing Egg:

1. [X] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [X] Have you tested your Egg changes?
