### PR TITLE
Bump default version to 1.16.5

### DIFF
--- a/minecraft/java/mohist/egg-mohist.json
+++ b/minecraft/java/mohist/egg-mohist.json
@@ -41,7 +41,7 @@
             "name": "Minecraft Version",
             "description": "The version of Minecraft to download.",
             "env_variable": "MC_VERSION",
-            "default_value": "1.16.5",
+            "default_value": "latest",
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|string|max:20"

--- a/minecraft/java/mohist/egg-mohist.json
+++ b/minecraft/java/mohist/egg-mohist.json
@@ -41,7 +41,7 @@
             "name": "Minecraft Version",
             "description": "The version of Minecraft to download.",
             "env_variable": "MC_VERSION",
-            "default_value": "1.16.4",
+            "default_value": "1.16.5",
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|string|max:20"

--- a/minecraft/java/mohist/egg-mohist.json
+++ b/minecraft/java/mohist/egg-mohist.json
@@ -41,7 +41,7 @@
             "name": "Minecraft Version",
             "description": "The version of Minecraft to download.",
             "env_variable": "MC_VERSION",
-            "default_value": "latest",
+            "default_value": "1.16.5",
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|string|max:20"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
 

### Changes to an existing Egg:

1. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [x] Have you tested your Egg changes?

### Description
So, Minecraft 1.16.5 is released, and Mohist bumped their latest builds to 1.16.5. **1.16.5 and 1.16.4 still crossplayable**, but 1.16.5 resolve some crashs, and is recommanded. 
