### PR TITLE
Add Valheim uMod egg with server/plugin auto-updates and plugin installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ If you are reading this it looks like you are looking to add an egg to your serv
 * [Team Fortress 2 Classic](/steamcmd_servers/team_fortress_2_classic)
 * [Unturned](/steamcmd_servers/unturned)
 * [Valheim](/steamcmd_servers/valheim)
+* [Valheim uMod](/steamcmd_servers/valheim_umod)
 
 [Teeworlds](/teeworlds)
 * [Teeworlds](/teeworlds/teeworlds)

--- a/steamcmd_servers/README.md
+++ b/steamcmd_servers/README.md
@@ -110,3 +110,6 @@ This is a collection of servers that use SteamCMD to install.
 
 ## Unturned
 [Unturned](unturned)
+
+## Valheim uMod
+[Valheim uMod] (valheim_umod)

--- a/steamcmd_servers/valheim_umod/README.md
+++ b/steamcmd_servers/valheim_umod/README.md
@@ -1,0 +1,11 @@
+# Valheim Server
+A brutal exploration and survival game for 1-10 players, set in a procedurally-generated purgatory inspired by viking culture. Battle, build, and conquer your way to a saga worthy of Odin’s patronage!
+
+uMod egg supports uMod installation, automated update of the game, uMod and the plugins together with auto-installation of plugins. uMod is still in early-development stage and as such issues might occur.
+
+## Server Ports
+
+| Port  | default |
+|-------|---------|
+| Game  | 2456   |
+| Query | 2457   |

--- a/steamcmd_servers/valheim_umod/egg-valheim-u-mod.json
+++ b/steamcmd_servers/valheim_umod/egg-valheim-u-mod.json
@@ -1,0 +1,112 @@
+{
+    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
+    "meta": {
+        "version": "PTDL_v1",
+        "update_url": null
+    },
+    "exported_at": "2021-02-26T05:52:40+02:00",
+    "name": "Valheim uMod",
+    "author": "admin@softwarenoob.com",
+    "description": "A brutal exploration and survival game for 1-10 players, set in a procedurally-generated purgatory inspired by viking culture.",
+    "features": null,
+    "images": [
+        "quay.io\/softwarenoob\/teast326:valheim"
+    ],
+    "startup": ".\/valheim_server.x86_64 -nographics -batchmode -name \"{{SERVER_NAME}}\" -port {{SERVER_PORT}} -world \"{{WORLD}}\" -password \"{{PASSWORD}}\" > >(sed -uE \"{{FILTER}}\") & trap \"{{STOP}}\" 15; wait $!",
+    "config": {
+        "files": "{}",
+        "startup": "{\r\n    \"done\": \"IP address from external\"\r\n}",
+        "logs": "{}",
+        "stop": "^C"
+    },
+    "scripts": {
+        "installation": {
+            "script": "#!\/bin\/bash\r\n# Valheim Installation Script\r\n\r\n# Server Files: \/vhs\/server\r\n# Image to install with is 'debian:buster-slim'\r\napt update && apt upgrade -y\r\napt -y install libgcc1 lib32gcc1 gdb libc6 git wget curl tar zip unzip net-tools ca-certificates\r\napt update -y && apt upgrade -y && wget https:\/\/packages.microsoft.com\/config\/debian\/10\/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && dpkg -i packages-microsoft-prod.deb && apt update -y && apt install -y dotnet-sdk-5.0 aspnetcore-runtime-5.0 libgdiplus\r\n\r\n## Initialize folder permissions\r\nmkdir -p \/mnt\/server\r\ncd \/mnt\/server\r\nchown -R root:root \/mnt\r\nexport HOME=\/mnt\/server\r\n\r\n\r\n# Configure dotnet\r\ncd \/mnt\/server\r\ndotnet tool update uMod --version \"*-*\" --global --add-source https:\/\/www.myget.org\/f\/umod\/api\/v3\/index.json\r\ndotnet new -i \"uMod.Templates::*-*\" --nuget-source https:\/\/www.myget.org\/f\/umod\/api\/v3\/index.json &>\/dev\/null\r\necho \"PATH=\\$PATH:\\$HOME\/.dotnet\/tools; export PATH\" >> ~\/.profile\r\necho \"DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1; export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT\" >> ~\/.profile\r\n\r\nmkdir .dotnet && cd .dotnet\r\ncurl -sSL -o dotnet-sdk.tar.gz https:\/\/dotnetcli.azureedge.net\/dotnet\/Sdk\/5.0.103\/dotnet-sdk-5.0.103-linux-x64.tar.gz.\r\ntar -xvf dotnet-sdk.tar.gz && rm dotnet-sdk.tar.gz && cd \/mnt\/server\r\n\r\n\r\n## install game\r\nchmod +x \/mnt\/server\/.dotnet\/tools\/umod\r\n.dotnet\/tools\/umod complete --install\r\n. ~\/.profile\r\numod install valheim -P\r\numod new launcher valheim -P --force\r\nchmod +x valheim_server.x86_64\r\n\r\n# Delete unnecessary files\r\nif [ -f \/mnt\/server\/start_server.sh ]; then\r\nrm launcher.sh umod-install.sh start_server.sh start_server_xterm.sh\r\nrm \"Valheim Dedicated Server Manual.pdf\"\r\nfi",
+            "container": "debian:buster-slim",
+            "entrypoint": "bash"
+        }
+    },
+    "variables": [
+        {
+            "name": "Server Name",
+            "description": "Name that appears in server browser.",
+            "env_variable": "SERVER_NAME",
+            "default_value": "Pterodactyl Server",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string|max:60"
+        },
+        {
+            "name": "Server Password",
+            "description": "Server password.",
+            "env_variable": "PASSWORD",
+            "default_value": "secret",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string|min:5|max:20"
+        },
+        {
+            "name": "World Name",
+            "description": "Name to load if switching between multiple saved worlds.",
+            "env_variable": "WORLD",
+            "default_value": "Dedicated",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string|max:20"
+        },
+        {
+            "name": "LD Library Path",
+            "description": "Required to load server libraries.",
+            "env_variable": "LD_LIBRARY_PATH",
+            "default_value": ".\/linux64",
+            "user_viewable": false,
+            "user_editable": false,
+            "rules": "required|string"
+        },
+        {
+            "name": "Console Filter",
+            "description": "Remove spam from the console output.",
+            "env_variable": "FILTER",
+            "default_value": "\/^\\(Filename:.*Line:[[:space:]]+[[:digit:]]+\\)$\/d; \/^([[:space:]]+)?$\/d",
+            "user_viewable": false,
+            "user_editable": false,
+            "rules": "string"
+        },
+        {
+            "name": "Shutdown Command",
+            "description": "Commands to trigger a server shutdown.",
+            "env_variable": "STOP",
+            "default_value": "kill -2 $!; wait;",
+            "user_viewable": false,
+            "user_editable": false,
+            "rules": "required|string"
+        },
+        {
+            "name": "Auto Update",
+            "description": "Auto-update uMod and the game each time server is started. Enter 0 to disable",
+            "env_variable": "AUTO_UPDATE",
+            "default_value": "1",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|boolean"
+        },
+        {
+            "name": "Update Plugins",
+            "description": "Auto-update plugins on server start, this will auto-update all plugins that are located in the plugins folder, even if not installed using the Install Plugins variable. Enter 0 to disable",
+            "env_variable": "UPDATE_PLUGINS",
+            "default_value": "1",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|boolean"
+        },
+        {
+            "name": "Install Plugins",
+            "description": "Install uMod plugins by entering their names separated by spaces, such as Autosave Sleepless Position MaxPlayers",
+            "env_variable": "INSTALL_PLUGINS",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "nullable|string"
+        }
+    ]
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:


### New Server Submissions:

1. [x] Does your submission pass tests (server is connectable)?
2. [ x] Does your server use a custom docker image?
    * [x] Have you tried to use a generic image?
    * [x] Did you PR the necessary changes to make it work?
3. [x] Have you added the server to the main README.md?
4. [x] Have you added a unique README.md for the server you are adding?


Requires the docker image from image repo to be merged first, afterwards the image for this egg will have to be updated. This egg installs uMod, handles automated updates of the game, app, plugins together with the installation of uMod plugins.

There are variables for updating the game, plugins, and installation of the plugins. Users can disable or enable them as they want, all plugins in the folder will be updated even if they're not installed through the install_plugins variable if automated plugin updates are enabled.

I wasn't exactly sure how to go about doing this egg, ex. should it behave like Rust with Oxide or not? At this moment uMod is in the very early development stage and things might break/change.