### PR TITLE
Valheim Readme fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,8 @@ If you are reading this it looks like you are looking to add an egg to your serv
   * [Arma 3](/steamcmd_servers/arma/arma3)
   * [Arma 3 64 Bit](/steamcmd_servers/arma/arma3_x64)
   * [Arma 3 Headless Client](/steamcmd_servers/arma/arma3_headless_client)
-* [Avorion](/steamcmd_servers/avorion)
 * [Assetto Corsa](/steamcmd_servers/assetto_corsa)
+* [Avorion](/steamcmd_servers/avorion)
 * [Barotrauma](/steamcmd_servers/barotrauma)
 * [Citadel: Forged with Fire](/steamcmd_servers/citadel)
 * [Conan Exiles](/steamcmd_servers/conan_exiles)
@@ -202,8 +202,6 @@ If you are reading this it looks like you are looking to add an egg to your serv
 [Unreal Engine](/unreal_engine)
 * [Tower Unite](/unreal_engine/tower_unite)
 * [Tower Unite](/steamcmd_servers/tower_unite)
-
-
 
 [Vintage Story](/vintage_story/vintage_story)
 

--- a/steamcmd_servers/README.md
+++ b/steamcmd_servers/README.md
@@ -14,11 +14,11 @@ This is a collection of servers that use SteamCMD to install.
   * [Arma 3 64 Bit](arma/arma3_x64)
   * [Arma 3 Headless Client](arma/arma3_headless_client)
 
-## Avorion
-[Avorion](avorion)
-
 ## Assetto Corsa
 [Assetto Corsa](assetto_corsa)
+
+## Avorion
+[Avorion](avorion)
 
 ## Barotrauma
 [Barotrauma](barotrauma)
@@ -121,6 +121,6 @@ This is a collection of servers that use SteamCMD to install.
 [Unturned](unturned)
 
 ## Valheim
-[Valheim](/valheim)
-  * [Valheim Vanilla](valheim_vanilla)
-  * [Valheim Plus Mod](valheim_plus)
+[Valheim](valheim)
+  * [Valheim Vanilla](valheim/valheim_vanilla)
+  * [Valheim Plus Mod](valheim/valheim_plus)

--- a/steamcmd_servers/valheim/valheim_plus/README.md
+++ b/steamcmd_servers/valheim/valheim_plus/README.md
@@ -1,10 +1,10 @@
 ﻿# Valheim Plus Mod
 
-##Valheim
+## Valheim
 A brutal exploration and survival game for 1-10 players, set in a procedurally-generated purgatory inspired by viking culture. Battle, build, and conquer your way to a saga worthy of Odin’s patronage!
 https://store.steampowered.com/app/892970/Valheim/
 
-##Plus Mod
+## Plus Mod
 A HarmonyX Mod aimed at improving the gameplay quality of Valheim. The mod includes several different main features including modifiers to ingame stats of players, buildings and entities and a sophisticated system to build and place objects with high precision and a system to modify already placed objects with high precision. The general goal is to provide V+ as a base modification for your gameplay to increase quality of life, change difficulty or have a better experience in general. The mod also comes with a version and configuration control system for servers and users, allowing servers to make sure that only people with the same configuration are able to join their servers.
 Support: https://github.com/valheimPlus/ValheimPlus
 Discord: https://discord.gg/AmH6Va97GT

--- a/steamcmd_servers/valheim/valheim_vanilla/README.md
+++ b/steamcmd_servers/valheim/valheim_vanilla/README.md
@@ -1,4 +1,4 @@
-# Valheim Server
+# Valheim
 A brutal exploration and survival game for 1-10 players, set in a procedurally-generated purgatory inspired by viking culture. Battle, build, and conquer your way to a saga worthy of Odin’s patronage!
 
 https://store.steampowered.com/app/892970/Valheim/


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Did you branch your changes and PR from that branch and not from your master branch?


The steamcmd readme did not contain valheim/ in the relative path, which leads to a 404 page as /valheim_vanilla is empty, it should be /valheim/valheim_vanilla

Also fixes the category formatting in the valheim_plus's readme to separate the blocks of text.

(Also puts assetto corsa above avorion, which is alphabetical order)
