### PR TITLE
proxy egg readme cleanup/fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,6 @@ If you are reading this it looks like you are looking to add an egg to your serv
   * [Cross Platform](/minecraft/proxy/cross_platform)
     * [GeyserMC](/minecraft/proxy/cross_platform/geyser)
     * [Waterdog](/minecraft/proxy/cross_platform/waterdog)
-    * DragonProxy abandoned in favour of GeyserMC.
 	
 [OpenRA](/openra)
 * [OpenRA Dune2000](/openra/openra_dune2000)

--- a/minecraft/proxy/README.md
+++ b/minecraft/proxy/README.md
@@ -8,4 +8,3 @@
 * [Cross Platform](/minecraft/proxy/cross_platform)
     * [GeyserMC](/minecraft/proxy/cross_platform/geyser)
     * [Waterdog](/minecraft/proxy/cross_platform/waterdog)
-	* DragonProxy abandoned in favour of GeyserMC.

--- a/minecraft/proxy/cross_platform/README.md
+++ b/minecraft/proxy/cross_platform/README.md
@@ -1,13 +1,13 @@
 # Mineraft Cross Platform Proxies
 
 ### GeyserMC
-[GeyserMC](https://github.com/GeyserMC/)
+[GeyserMC](https://github.com/GeyserMC)
 
 A bridge/proxy allowing you to connect to Minecraft: Java Edition servers with Minecraft: Bedrock edition.
 
 
-#### Waterdog
-[Waterdog](https://github.com/yesdog/Waterdog)
+### Waterdog
+[Waterdog](https://github.com/WaterdogPE/Waterdog)
 
 Waterdog provides native support for the Minecraft Bedrock protocols along with the existing java protocols. It is capable of using the ProtocolSupport PE encapsulation protocol over TCP, or it can use the native RakNet Bedrock protocol for traditional downstream Bedrock servers such as Nukkit, Pocketmine, Bedrock Alpha Server, MiNET, and others.
 

--- a/minecraft/proxy/java/README.md
+++ b/minecraft/proxy/java/README.md
@@ -1,17 +1,18 @@
 # Minecraft Java Proxies
 
-#### Waterfall
-[Waterfall](https://papermc.io/downloads#Waterfall)
-Paper fork of the BungeeCord software, with improved Forge support and more features.
 
 #### Travertine
 [Travertine](https://papermc.io/downloads#Travertine)
 Waterfall, with additional support for Minecraft 1.7.10. 
 
+#### TyphoonLimbo
+[TyphoonLimbo](https://github.com/TyphoonMC/TyphoonLimbo)
+A limbo server is a fallback server able to handle a massive amount of simultaneous connections. The player spawns into the void then waits here. It can be used to keep players connected to a network after a lobby crashed or as an afk server.
+
 #### Velocity
-[Velocity](https://velocitypowered.com/)
+[Velocity](https://velocitypowered.com)
 Velocity is a Minecraft server proxy with unparalleled server support, scalability, and flexibility. 
 
-#### Typhoonlimbo
-[TyphoonLimbo](https://github.com/TyphoonMC/TyphoonLimbo)
-Lightweight Minecraft limbo server  
+#### Waterfall
+[Waterfall](https://papermc.io/downloads#Waterfall)
+Paper fork of the BungeeCord software, with improved Forge support and more features.

--- a/minecraft/proxy/java/typhoonlimbo/README.md
+++ b/minecraft/proxy/java/typhoonlimbo/README.md
@@ -1,5 +1,5 @@
 # TyphoonLimbo server
-Lightweight minecraft limbo server 
+A limbo server is a fallback server able to handle a massive amount of simultaneous connections. The player spawns into the void then waits here. It can be used to keep players connected to a network after a lobby crashed or as an afk server.
 
 ## Server Ports
 The minecraft server requires a single port for access (default 25565) but plugins may require extra ports to enabled for the server.


### PR DESCRIPTION
Updates waterdog's github link to the current repo
Alphabetically orders the java proxies list
Adds the more descriptive description to typhoon limbo's readme.
Removed all traces of "DragonProxy" as it's completely abandoned

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:
