### PR TITLE
Add Java 16 for PaperMC

### DIFF
--- a/minecraft/java/paper/egg-paper.json
+++ b/minecraft/java/paper/egg-paper.json
@@ -8,11 +8,12 @@
     "author": "parker@pterodactyl.io",
     "description": "High performance Spigot fork that aims to fix gameplay and mechanics inconsistencies.",
     "features": ["eula"],
-    "image": "quay.io\/pterodactyl\/core:java-11",
+    "image": "quay.io\/parkervcp\/pterodactyl-images:debian_openjdk-16",
     "images": [
         "quay.io\/pterodactyl\/core:java-11",
         "quay.io\/pterodactyl\/core:java",
-        "quay.io\/parkervcp\/pterodactyl-images:debian_openjdk-15"
+        "quay.io\/parkervcp\/pterodactyl-images:debian_openjdk-15",
+        "quay.io\/parkervcp\/pterodactyl-images:debian_openjdk-16"
     ],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",
     "config": {


### PR DESCRIPTION
With the future Minecrfat 1.17 release, PaperMC will need Java 16 => https://papermc.io/forums/t/java-16-mc-1-17-and-paper/5615


### Changes to an existing Egg:

1. [YES] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [NO] Have you tested your Egg changes?
