### PR TITLE
Fixed the Github link in Lavalink's Readme.md

### DIFF
--- a/voice_servers/lavalink/README.md
+++ b/voice_servers/lavalink/README.md
@@ -1,5 +1,5 @@
 # Lavalink Server
-### From their [Github](https://github.com/Frederikam/Lavalink)
+### From their [Github](https://github.com/freyacodes/Lavalink)
 Standalone audio sending node based on Lavaplayer and JDA-Audio. Allows for sending audio without it ever reaching any of your shards.
 
 ### Server Ports


### PR DESCRIPTION
Fixed the Lavalink's Readme.md's Github link.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?: