### PR TITLE
Change images to yolks to prevent confusion

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@
     Only use what is absolutely needed.  
 
 3. Try to stay in the stock containers.  
-    If you need something in a container PR it to [my image repo](https://github.com/parkervcp/images) where I can review and pull up to the main repo.
+    If you need something in a container PR it to [my yolks repo](https://github.com/parkervcp/yolks) where I can review and pull up to the main repo.
 
 4. Don't be afraid to submit PR's to the egg repo.  
     I don't bite. I will work with you on the egg and the required things to run it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@
     Only use what is absolutely needed.  
 
 3. Try to stay in the stock containers.  
-    If you need something in a container PR it to [my yolks repo](https://github.com/parkervcp/yolks) where I can review and pull up to the main repo.
+    If you need something in a container, open a PR in [my yolks repo](https://github.com/parkervcp/yolks) where I can review and pull it up to the main repo. In addition, there is a larger quantity of [images here](https://github.com/parkervcp/images) for you to use that have not been migrated to Yolks yet.
 
 4. Don't be afraid to submit PR's to the egg repo.  
     I don't bite. I will work with you on the egg and the required things to run it.


### PR DESCRIPTION
### Documentation adjustment
There was some confusion in the Discord about where to contribute new images to as yolks is the new images repository.

This PR solves future headache by:

- Changing `my image repo` to `my yolks repo` to tell people the new repository for images is yolks.
- Changing the repository url to `parkervcp/yolks`
  - Tells contributors to use the yolks repo
  - Tells contributors also that they should contribute to `parkervcp/yolks` instead of the main `pterodactyl/yolks` repository

### All Submissions:
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Did you branch your changes and PR from that branch and not from your master branch?