### PR TITLE
patch: purpur to use new v2 api

### DIFF
--- a/game_eggs/minecraft/java/purpur/egg-purpur.json
+++ b/game_eggs/minecraft/java/purpur/egg-purpur.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v1",
         "update_url": null
     },
-    "exported_at": "2021-07-02T04:03:33+03:00",
+    "exported_at": "2021-07-17T01:51:57+03:00",
     "name": "Purpur",
     "author": "purpur@birdflop.com",
     "description": "Fork of Paper and Tuinity providing new configuration options.",
@@ -12,22 +12,21 @@
         "eula"
     ],
     "images": [
+        "ghcr.io\/pterodactyl\/yolks:java_16",
         "ghcr.io\/pterodactyl\/yolks:java_11",
-        "ghcr.io\/pterodactyl\/yolks:java_8",
-        "ghcr.io\/pterodactyl\/yolks:java_14",
-        "ghcr.io\/pterodactyl\/yolks:java_16"
+        "ghcr.io\/pterodactyl\/yolks:java_8"
     ],
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",
     "config": {
         "files": "{\r\n    \"server.properties\": {\r\n        \"parser\": \"properties\",\r\n        \"find\": {\r\n            \"server-ip\": \"0.0.0.0\",\r\n            \"server-port\": \"{{server.build.default.port}}\"\r\n        }\r\n    }\r\n}",
-        "startup": "{\r\n    \"done\": \")! For help, type \",\r\n    \"userInteraction\": [\r\n        \"Go to eula.txt for more info.\"\r\n    ]\r\n}",
+        "startup": "{\r\n    \"done\": \")! For help, type \"\r\n}",
         "logs": "{}",
         "stop": "stop"
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/bash\r\n# Purpur Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\n\r\napt update\r\napt install -y curl jq\r\n\r\nVER_EXISTS=`curl -s https:\/\/purpur.pl3x.net\/api\/v1\/purpur | jq -r --arg VERSION $MINECRAFT_VERSION '.versions[] | contains($VERSION)' | grep true`\r\nLATEST_PURPUR_VERSION=`curl -s https:\/\/purpur.pl3x.net\/api\/v1\/purpur | jq -r '.versions' | jq -r '.[0]'`\r\n\r\nif [ \"${VER_EXISTS}\" == \"true\" ]; then\r\n    echo -e \"Version is valid. Using version ${MINECRAFT_VERSION}\"\r\nelse\r\n    echo -e \"Using the latest Purpur version\"\r\n    MINECRAFT_VERSION=${LATEST_PURPUR_VERSION}\r\nfi\r\n\r\nBUILD_EXISTS=`curl -s https:\/\/purpur.pl3x.net\/api\/v1\/purpur\/${MINECRAFT_VERSION} | jq -r --arg BUILD ${BUILD_NUMBER} '.builds.all[] | contains($BUILD)' | grep true`\r\nLATEST_PURPUR_BUILD=`curl -s https:\/\/purpur.pl3x.net\/api\/v1\/purpur\/${MINECRAFT_VERSION} | jq -r '.builds.latest'`\r\n\r\nif [ \"${BUILD_EXISTS}\" == \"true\" ] || [ ${BUILD_NUMBER} == \"latest\" ]; then\r\n    echo -e \"Build is valid. Using version ${BUILD_NUMBER}\"\r\nelse\r\n    echo -e \"Using the latest Purpur build\"\r\n    BUILD_NUMBER=${LATEST_PURPUR_BUILD}\r\nfi\r\n\r\necho \"Version being downloaded\"\r\necho -e \"MC Version: ${MINECRAFT_VERSION}\"\r\necho -e \"Build: ${BUILD_NUMBER}\"\r\nDOWNLOAD_URL=https:\/\/purpur.pl3x.net\/api\/v1\/purpur\/${MINECRAFT_VERSION}\/${BUILD_NUMBER}\/download \r\n\r\n\r\ncd \/mnt\/server\r\n\r\necho -e \"running curl -o ${SERVER_JARFILE} ${DOWNLOAD_URL}\"\r\n\r\nif [ -f ${SERVER_JARFILE} ]; then\r\n    mv ${SERVER_JARFILE} ${SERVER_JARFILE}.old\r\nfi\r\n\r\ncurl -o ${SERVER_JARFILE} ${DOWNLOAD_URL}\r\n\r\nif [ ! -f server.properties ]; then\r\n    echo -e \"Downloading MC server.properties\"\r\n    curl -sSL -o server.properties https:\/\/raw.githubusercontent.com\/parkervcp\/eggs\/master\/game_eggs\/minecraft\/java\/server.properties\r\nfi",
+            "script": "#!\/bin\/bash\r\n# Purpur Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\n\r\napt update\r\napt install -y curl jq\r\n\r\nVER_EXISTS=`curl -s https:\/\/api.pl3x.net\/v2\/purpur\/ | jq -r --arg VERSION $MINECRAFT_VERSION '.versions[] | contains($VERSION)?' | grep true`\r\nLATEST_PURPUR_VERSION=`curl -s https:\/\/api.pl3x.net\/v2\/purpur\/ | jq -r '.versions' | jq -r '.[0]?'`\r\n\r\nif [ \"${VER_EXISTS}\" == \"true\" ]; then\r\n    echo -e \"Chosen version is valid. Using version ${MINECRAFT_VERSION}\"\r\nelse\r\n    echo -e \"Chosen version is invalid. Defaulting to the latest Purpur version\"\r\n    MINECRAFT_VERSION=${LATEST_PURPUR_VERSION}\r\nfi\r\n\r\nBUILD_EXISTS=`curl -s https:\/\/api.pl3x.net\/v2\/purpur\/${MINECRAFT_VERSION}\/ | jq -r --arg BUILD $BUILD_NUMBER '.builds.all[] | contains($BUILD)?' | grep true`\r\nLATEST_PURPUR_BUILD=`curl -s https:\/\/api.pl3x.net\/v2\/purpur\/${MINECRAFT_VERSION}\/ | jq -r '.builds.latest'`\r\n\r\nif [ \"${BUILD_EXISTS}\" == \"true\" ] || [ ${BUILD_NUMBER} == \"latest\" ]; then\r\n    echo -e \"Chosen build is valid. Using version ${BUILD_NUMBER}\"\r\nelse\r\n    echo -e \"Chosen version is invalid. Using the latest Purpur build\"\r\n    BUILD_NUMBER=${LATEST_PURPUR_BUILD}\r\nfi\r\n\r\necho \"Version being downloaded\"\r\necho -e \"MC Version: ${MINECRAFT_VERSION}\"\r\necho -e \"Build: ${BUILD_NUMBER}\"\r\nDOWNLOAD_URL=https:\/\/api.pl3x.net\/v2\/purpur\/${MINECRAFT_VERSION}\/${BUILD_NUMBER}\/download \r\n\r\ncd \/mnt\/server\r\n\r\necho -e \"running curl -o ${SERVER_JARFILE} ${DOWNLOAD_URL}\"\r\n\r\nif [ -f ${SERVER_JARFILE} ]; then\r\n    mv ${SERVER_JARFILE} ${SERVER_JARFILE}.old\r\nfi\r\n\r\ncurl -o ${SERVER_JARFILE} ${DOWNLOAD_URL}\r\n\r\nif [ ! -f server.properties ]; then\r\n    echo -e \"Downloading MC server.properties\"\r\n    curl -sSL -o server.properties https:\/\/raw.githubusercontent.com\/parkervcp\/eggs\/master\/game_eggs\/minecraft\/java\/server.properties\r\nfi",
             "container": "debian:buster-slim",
             "entrypoint": "bash"
         }


### PR DESCRIPTION
Uses latest purpur v2 API version, together with ignoring null values in jq contains that could trigger invalid results.

Removes java 14 that was deleted from yolks and expands echo debug messages. [Diff between files.](https://editor.mergely.com/ZJKZGBdw/)

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

### Changes to an existing Egg:

1. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [x] Have you tested your Egg changes?
