### PR TITLE
Updating Minetest Egg for Pterodactyl's Productivity Improvements and…

### DIFF
--- a/game_eggs/minetest/minetest/egg-minetest.json
+++ b/game_eggs/minetest/minetest/egg-minetest.json
@@ -8,12 +8,12 @@
     "author": "support@pterodactyl.io",
     "description": "An open source voxel game engine. Play one of our many games, mod a game to your liking, make your own game, or play on a multiplayer server.",
     "image": "quay.io\/parkervcp\/pterodactyl-images:base_ubuntu",
-    "startup": ".\/bin\/minetestserver --port {{SERVER_PORT}}",
+    "startup": ".\/bin\/minetestserver --port {{SERVER_PORT}} --terminal",
     "config": {
         "files": "{}",
-        "startup": "{\r\n    \"done\": \" listening on \",\r\n    \"userInteraction\": []\r\n}",
+        "startup": "{\r\n    \"done\": \" Server for gameid\",\r\n    \"userInteraction\": []\r\n}",
         "logs": "{\r\n    \"custom\": false,\r\n    \"location\": \"debug.txt\"\r\n}",
-        "stop": "^C"
+        "stop": "\/shutdown"
     },
     "scripts": {
         "installation": {
@@ -27,7 +27,7 @@
             "name": "Version",
             "description": "The version of MT to install. Releases only",
             "env_variable": "MTVERSION",
-            "default_value": "5.3.0",
+            "default_value": "5.4.1",
             "user_viewable": false,
             "user_editable": true,
             "rules": "required|string|max:10"


### PR DESCRIPTION
… Default Versioning

Hiya there! I was tired of having a "half ash" setup that this "stock" egg supplied so I "messed" with the .json and came up with the following... 
Added --terminal so the server ACTUALLY starts in a working terminal just like Minecraft servers do (you can either talk in it without the "/" or execute commands as the set admin).
Changed Stop command from the "^C" now that "/shutdown" can be used because of a working terminal
Changed "done" to "Server for gameid" because it wasn't working after these changes for " listening on " on my end. 
Updated Versioning to 5.4.1 instead of now dated 5.3.0

Caveat: Slightly annoying but the game requires you to input a name for the Admin User by the use of putting "name=youradmin" into the minetest.conf of the instance. As well as logging in as that admin WITH a ingame password. But hey that's progress I am not right?

Hope my hours helps those who were looking for a Minetest egg that is more productive as well up to date!

