### PR TITLE
Add a option to uninstall node modules with the discord.js egg

### DIFF
--- a/bots/discord/discord.js/egg-discord-js-generic.json
+++ b/bots/discord/discord.js/egg-discord-js-generic.json
@@ -17,7 +17,7 @@
         "quay.io\/parkervcp\/pterodactyl-images:debian_nodejs-10"
     ],
     "file_denylist": [],
-    "startup": "if [[ -d .git ]] && [[ {{AUTO_UPDATE}} == \"1\" ]]; then git pull; fi; if [[ ! -z ${NODE_PACKAGES} ]]; then \/usr\/local\/bin\/npm install ${NODE_PACKAGES}; fi; if [ -f \/home\/container\/package.json ]; then  \/usr\/local\/bin\/npm install --production; fi; \/usr\/local\/bin\/node \/home\/container\/{{BOT_JS_FILE}}",
+    "startup": "if [[ -d .git ]] && [[ {{AUTO_UPDATE}} == \"1\" ]]; then git pull; fi; if [[ ! -z ${NODE_PACKAGES} ]]; then \/usr\/local\/bin\/npm install ${NODE_PACKAGES}; fi; if [[ ! -z ${UNNODE_PACKAGES} ]]; then \/usr\/local\/bin\/npm uninstall ${UNNODE_PACKAGES}; fi; if [ -f \/home\/container\/package.json ]; then  \/usr\/local\/bin\/npm install --production; fi; \/usr\/local\/bin\/node \/home\/container\/{{BOT_JS_FILE}}",
     "config": {
         "files": "{}",
         "startup": "{\r\n    \"done\": \"change this part\"\r\n}",
@@ -80,6 +80,15 @@
         {
             "name": "Additional Node packages",
             "description": "Install additional node packages.\r\n\r\nUse spaces to separate.",
+            "env_variable": "NODE_PACKAGES",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "nullable|string"
+        },
+        {
+            "name": "Uninstall Node packages",
+            "description": "Uninstall node packages.\r\n\r\nUse spaces to separate.",
             "env_variable": "NODE_PACKAGES",
             "default_value": "",
             "user_viewable": true,


### PR DESCRIPTION
This pr adds a feature that allows users to uninstall node modules rather than doing it manually.

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

1. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [x] Have you tested your Egg changes?
