### PR TITLE
fix link issue for pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 ### All Submissions:
 
 * [ ] Have you followed the guidelines in our Contributing document?
-* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
+* [ ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
 * [ ] Did you branch your changes and PR from that branch and not from your master branch?
   * If not, why?:
 


### PR DESCRIPTION
This should fix the issue of going to https://github.com/parkervcp/pulls instead of https://github.com/parkervcp/eggs/pulls