### PR TITLE
fix: Impostor server version download

### DIFF
--- a/game_eggs/among_us/impostor_server/README.md
+++ b/game_eggs/among_us/impostor_server/README.md
@@ -2,12 +2,11 @@
 ### From their [Github](https://github.com/AeonLucid/Impostor)
 
 Impostor is one of the first Among Us private servers, written in C#.
-The latest version supported is 2020.9.22, both desktop and mobile.
 There are no special features at this moment, the goal is aiming to be as close as possible to the real server, for now. In a later stage, making modifications to game logic by modifying GameData packets can be looked at.
 
 ### Install notes
 
-You MUST use Port 22023, else you can't connect
+You MUST use Port 22023 for the Master Server. To host multiple servers, please read [Impostor Multiple Servers Documentation](https://github.com/Impostor/Impostor/blob/master/docs/Running-the-server.md#multiple-servers).
 
 ### Server Ports
 Ports required to run the server in a table format.

--- a/game_eggs/among_us/impostor_server/egg-among-us--impostor-server.json
+++ b/game_eggs/among_us/impostor_server/egg-among-us--impostor-server.json
@@ -1,50 +1,36 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
-        "version": "PTDL_v1"
+        "version": "PTDL_v1",
+        "update_url": null
     },
-    "exported_at": "2020-11-20T15:01:04+01:00",
+    "exported_at": "2021-07-23T12:00:05+03:00",
     "name": "Among Us - Impostor Server",
     "author": "info@goover.de",
     "description": "Impostor is one of the first Among Us private servers, written in C#.\r\n\r\nThe latest version supported is 2020.9.22, both desktop and mobile.\r\n\r\nThere are no special features at this moment, the goal is aiming to be as close as possible to the real server, for now. In a later stage, making modifications to game logic by modifying GameData packets can be looked at.",
     "features": null,
-    "image": "quay.io\/parkervcp\/pterodactyl-images:debian_dotnet-5",
+    "images": [
+        "quay.io\/parkervcp\/pterodactyl-images:debian_dotnet-5"
+    ],
+    "file_denylist": [],
     "startup": ".\/Impostor.Server",
     "config": {
         "files": "{\r\n    \"config.json\": {\r\n        \"parser\": \"json\",\r\n        \"find\": {\r\n            \"Server.PublicPort\": \"{{server.build.default.port}}\",\r\n            \"Server.ListenPort\": \"{{server.build.default.port}}\"\r\n        }\r\n    }\r\n}",
-        "startup": "{\r\n    \"done\": \"Matchmaker is listening on\",\r\n    \"userInteraction\": []\r\n}",
+        "startup": "{\r\n    \"done\": \"Matchmaker is listening on\"\r\n}",
         "logs": "{}",
-        "stop": "^C"
+        "stop": "^^C"
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/bash\r\n\r\napt -y update\r\napt -y upgrade\r\napt -y --no-install-recommends install wget curl jq unzip tar redis-server file ca-certificates apt-utils\r\n\r\nexport HOME=\/mnt\/server\r\ncd $HOME\r\n\r\n## get release info and download links\r\nLATEST_RELEASE=$(curl -L -s -H 'Accept: application\/json' https:\/\/github.com\/${GITHUB_PACKAGE}\/releases\/latest)\r\nLATEST_VERSION=$(echo $LATEST_RELEASE | sed -e 's\/.*\"tag_name\":\"\\([^\"]*\\)\".*\/\\1\/')\r\n\r\nif [ -z \"${VERSION}\" ] || [ \"${VERSION}\" == \"latest\" ]; then\r\n    DOWNLOAD_LINK=\"https:\/\/github.com\/${GITHUB_PACKAGE}\/releases\/download\/$LATEST_VERSION\/$MATCH\"\r\nelse \r\n    DOWNLOAD_LINK=\"https:\/\/github.com\/${GITHUB_PACKAGE}\/releases\/download\/v$VERSION\/$MATCH\"\r\nfi\r\n\r\necho $DOWNLOAD_LINK\r\nwget $DOWNLOAD_LINK\r\n\r\nunzip -o Impostor-Server-linux-x64.zip\r\nrm -fR Impostor-Server-linux-x64.zip \r\nchmod +x Impostor.Server",
+            "script": "#!\/bin\/bash\r\n\r\napt -y update\r\napt -y --no-install-recommends install wget curl jq unzip tar redis-server file ca-certificates apt-utils\r\nGITHUB_PACKAGE=Impostor\/Impostor\r\nexport HOME=\/mnt\/server\r\ncd $HOME\r\n\r\n## get release info and download links\r\nLATEST_RELEASE=$(curl -L -s -H 'Accept: application\/json' https:\/\/github.com\/${GITHUB_PACKAGE}\/releases\/latest)\r\necho -e \"Latest release is $LATEST_RELEASE\"\r\nLATEST_VERSION_TAG=$(echo $LATEST_RELEASE | sed -e 's\/.*\"tag_name\":\"\\([^\"]*\\)\".*\/\\1\/')\r\n\r\n# Remove the first letter v from the version tag that is not present in the download URL\r\nLATEST_VERSION=$(echo $LATEST_VERSION_TAG | cut -c 2-)\r\n\r\nif [ -z \"${VERSION}\" ] || [ \"${VERSION}\" == \"latest\" ]; then\r\n    DOWNLOAD_LINK=\"https:\/\/github.com\/${GITHUB_PACKAGE}\/releases\/download\/v$LATEST_VERSION\/Impostor-Server_${LATEST_VERSION}_linux-x64.tar.gz\"\r\nelse \r\n    DOWNLOAD_LINK=\"https:\/\/github.com\/${GITHUB_PACKAGE}\/releases\/download\/v$VERSION\/Impostor-Server_${VERSION}_linux-x64.tar.gz\"\r\nfi\r\n\r\necho -e \"\\nDownloading from $DOWNLOAD_LINK\"\r\ncurl -L $DOWNLOAD_LINK -o Impostor-Server-linux-x64.tar.gz\r\n\r\ntar xvf Impostor-Server-linux-x64.tar.gz\r\nrm Impostor-Server-linux-x64.tar.gz\r\nchmod +x Impostor.Server\r\n\r\necho -e \"\\nInstall completed\"",
             "container": "debian:buster-slim",
             "entrypoint": "bash"
         }
     },
     "variables": [
         {
-            "name": "GITHUB_PACKAGE",
-            "description": "GITHUB_PACKAGE",
-            "env_variable": "GITHUB_PACKAGE",
-            "default_value": "Impostor\/Impostor",
-            "user_viewable": false,
-            "user_editable": false,
-            "rules": "required"
-        },
-        {
-            "name": "MATCH",
-            "description": "Filename to Match",
-            "env_variable": "MATCH",
-            "default_value": "Impostor-Server-linux-x64.zip",
-            "user_viewable": false,
-            "user_editable": false,
-            "rules": "required"
-        },
-        {
-            "name": "Version",
-            "description": "Version to Download.",
+            "name": "Download Version",
+            "description": "Version to Download. Leave latest for the latest release.\r\n\r\nFind all releases at https:\/\/github.com\/Impostor\/Impostor\/releases",
             "env_variable": "VERSION",
             "default_value": "latest",
             "user_viewable": true,


### PR DESCRIPTION
Updates impostor to use the new version format, cleans up the install script, and corrects wrong information in the readme. Supersedes #1143

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

### Changes to an existing Egg:

1. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [x] Have you tested your Egg changes?
