### PR TITLE
Update Technic eggs and Readme

### DIFF
--- a/game_eggs/minecraft/java/technic/README.md
+++ b/game_eggs/minecraft/java/technic/README.md
@@ -1,10 +1,10 @@
 ## Technic Eggs
 
-[Technic](/minecraft/java/technic/)   
-* [Attack of the B-Team](/minecraft/java/technic/attack-of-the-bteam/)
-* [Blightfall](/minecraft/java/technic/blightfall/)
-* [Hexxit](/minecraft/java/technic/hexxit/)  
-* [Tekkit](/minecraft/java/technic/Tekkit/)
-* [Tekkit Classic](/minecraft/java/technic/tekkit-classic/)
-* [Tekkit Legends](/minecraft/java/technic/tekkit-legends/)
-* [The 1.7.10 Pack](/minecraft/java/technic/the-1-7-10-pack/)
+[Technic](/game_eggs/minecraft/java/technic/)
+* [Attack of the B-Team](/game_eggs/minecraft/java/technic/attack-of-the-bteam/)
+* [Blightfall](/game_eggs/minecraft/java/technic/blightfall/)
+* [Hexxit](/game_eggs/minecraft/java/technic/hexxit/)
+* [Tekkit](/game_eggs/minecraft/java/technic/Tekkit/)
+* [Tekkit Classic](/game_eggs/minecraft/java/technic/tekkit-classic/)
+* [Tekkit Legends](/game_eggs/minecraft/java/technic/tekkit-legends/)
+* [The 1.7.10 Pack](/game_eggs/minecraft/java/technic/the-1-7-10-pack/)

--- a/game_eggs/minecraft/java/technic/README.md
+++ b/game_eggs/minecraft/java/technic/README.md
@@ -8,3 +8,4 @@
 * [Tekkit Classic](/game_eggs/minecraft/java/technic/tekkit-classic/)
 * [Tekkit Legends](/game_eggs/minecraft/java/technic/tekkit-legends/)
 * [The 1.7.10 Pack](/game_eggs/minecraft/java/technic/the-1-7-10-pack/)
+* [The 1.12.2 Pack](/game_eggs/minecraft/java/technic/the-1-12-2-pack/)

--- a/game_eggs/minecraft/java/technic/Tekkit/egg-tekkit.json
+++ b/game_eggs/minecraft/java/technic/Tekkit/egg-tekkit.json
@@ -22,7 +22,7 @@
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/ash\r\n# Forge Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\napk update\r\napk add curl\r\n\r\ncd \/mnt\/server\r\n\r\ncurl -sSL http:\/\/servers.technicpack.net\/Technic\/servers\/tekkitmain\/Tekkit_Server_$MODPACK_VERSION.zip -o Tekkit_Server_$MODPACK_VERSION.zip\r\n\r\nunzip Tekkit_Server_$MODPACK_VERSION.zip\r\n\r\nrm -rf Tekkit_Server_$MODPACK_VERSION.zip\r\n\r\nrm launch.bat\r\n\r\nrm launch.sh\r\n\r\nif [ ! -f server.properties ]; then\r\n    echo -e \"Downloading MC server.properties\"\r\n    curl -o server.properties https:\/\/raw.githubusercontent.com\/parkervcp\/eggs\/master\/game_eggs\/minecraft\/java\/server.properties\r\nfi",
+            "script": "#!\/bin\/ash\r\n# Forge Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\napk update\r\napk add curl\r\n\r\ncd \/mnt\/server\r\n\r\ncurl -sSL https:\/\/servers.technicpack.net\/Technic\/servers\/tekkitmain\/Tekkit_Server_$MODPACK_VERSION.zip -o Tekkit_Server_$MODPACK_VERSION.zip\r\n\r\nunzip Tekkit_Server_$MODPACK_VERSION.zip\r\n\r\nrm -rf Tekkit_Server_$MODPACK_VERSION.zip\r\n\r\nrm launch.bat\r\n\r\nrm launch.sh\r\n\r\nif [ ! -f server.properties ]; then\r\n    echo -e \"Downloading MC server.properties\"\r\n    curl -o server.properties https:\/\/raw.githubusercontent.com\/parkervcp\/eggs\/master\/game_eggs\/minecraft\/java\/server.properties\r\nfi",
             "container": "alpine:3.9",
             "entrypoint": "ash"
         }

--- a/game_eggs/minecraft/java/technic/attack-of-the-bteam/egg-attack-of-the-b--team.json
+++ b/game_eggs/minecraft/java/technic/attack-of-the-bteam/egg-attack-of-the-b--team.json
@@ -17,7 +17,7 @@
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/ash\r\n# Forge Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\napk update\r\napk add curl\r\n\r\ncd \/mnt\/server\r\n\r\ncurl -sS http:\/\/servers.technicpack.net\/Technic\/servers\/bteam\/BTeam_Server_v$MODPACK_VERSION.zip -o BTeam_Server_v$MODPACK_VERSION.zip\r\n\r\nunzip BTeam_Server_v$MODPACK_VERSION.zip\r\n\r\nrm -rf BTeam_Server_v$MODPACK_VERSION.zip",
+            "script": "#!\/bin\/ash\r\n# Forge Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\napk update\r\napk add curl\r\n\r\ncd \/mnt\/server\r\n\r\ncurl -sS https:\/\/servers.technicpack.net\/Technic\/servers\/bteam\/BTeam_Server_v$MODPACK_VERSION.zip -o BTeam_Server_v$MODPACK_VERSION.zip\r\n\r\nunzip BTeam_Server_v$MODPACK_VERSION.zip\r\n\r\nrm -rf BTeam_Server_v$MODPACK_VERSION.zip",
             "container": "alpine:3.9",
             "entrypoint": "ash"
         }

--- a/game_eggs/minecraft/java/technic/blightfall/egg-blightfall.json
+++ b/game_eggs/minecraft/java/technic/blightfall/egg-blightfall.json
@@ -17,7 +17,7 @@
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/ash\r\n# Forge Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\napk update\r\napk add curl\r\n\r\ncd \/mnt\/server\r\n\r\ncurl -sS http:\/\/servers.technicpack.net\/Technic\/servers\/blightfall\/Blightfall_Server_v$MODPACK_VERSION.zip -o Blightfall_$MODPACK_VERSION.zip\r\n\r\nunzip Blightfall_$MODPACK_VERSION.zip\r\n\r\nrm -rf Blightfall_$MODPACK_VERSION.zip",
+            "script": "#!\/bin\/ash\r\n# Forge Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\napk update\r\napk add curl\r\n\r\ncd \/mnt\/server\r\n\r\ncurl -sS https:\/\/servers.technicpack.net\/Technic\/servers\/blightfall\/Blightfall_Server_v$MODPACK_VERSION.zip -o Blightfall_$MODPACK_VERSION.zip\r\n\r\nunzip Blightfall_$MODPACK_VERSION.zip\r\n\r\nrm -rf Blightfall_$MODPACK_VERSION.zip",
             "container": "alpine:3.9",
             "entrypoint": "ash"
         }

--- a/game_eggs/minecraft/java/technic/hexxit/egg-hexxit.json
+++ b/game_eggs/minecraft/java/technic/hexxit/egg-hexxit.json
@@ -17,7 +17,7 @@
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/ash\r\n# Forge Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\napk update\r\napk add curl\r\n\r\ncd \/mnt\/server\r\n\r\ncurl -sS http:\/\/servers.technicpack.net\/Technic\/servers\/hexxit\/Hexxit_Server_v$MODPACK_VERSION.zip -o Hexxit_$MODPACK_VERSION.zip\r\n\r\nunzip Hexxit_$MODPACK_VERSION.zip\r\n\r\nrm -rf Hexxit_$MODPACK_VERSION.zip",
+            "script": "#!\/bin\/ash\r\n# Forge Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\napk update\r\napk add curl\r\n\r\ncd \/mnt\/server\r\n\r\ncurl -sS https:\/\/servers.technicpack.net\/Technic\/servers\/hexxit\/Hexxit_Server_v$MODPACK_VERSION.zip -o Hexxit_$MODPACK_VERSION.zip\r\n\r\nunzip Hexxit_$MODPACK_VERSION.zip\r\n\r\nrm -rf Hexxit_$MODPACK_VERSION.zip",
             "container": "alpine:3.9",
             "entrypoint": "ash"
         }

--- a/game_eggs/minecraft/java/technic/tekkit-classic/egg-tekkit-classic.json
+++ b/game_eggs/minecraft/java/technic/tekkit-classic/egg-tekkit-classic.json
@@ -22,7 +22,7 @@
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/ash\r\n# Forge Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\napk update\r\napk add curl\r\n\r\ncd \/mnt\/server\r\n\r\ncurl -sS http:\/\/servers.technicpack.net\/Technic\/servers\/tekkit\/Tekkit_Server_$MODPACK_VERSION.zip -o Tekkit_Server_$MODPACK_VERSION.zip\r\n\r\nunzip Tekkit_Server_$MODPACK_VERSION.zip\r\n\r\nrm -rf Tekkit_Server_$MODPACK_VERSION.zip\r\n\r\nrm launch.bat\r\n\r\nrm launch.sh\r\n\r\nif [ ! -f server.properties ]; then\r\n    echo -e \"Downloading MC server.properties\"\r\n    curl -o server.properties https:\/\/raw.githubusercontent.com\/parkervcp\/eggs\/master\/game_eggs\/minecraft\/java\/server.properties\r\nfi",
+            "script": "#!\/bin\/ash\r\n# Forge Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\napk update\r\napk add curl\r\n\r\ncd \/mnt\/server\r\n\r\ncurl -sS https:\/\/servers.technicpack.net\/Technic\/servers\/tekkit\/Tekkit_Server_$MODPACK_VERSION.zip -o Tekkit_Server_$MODPACK_VERSION.zip\r\n\r\nunzip Tekkit_Server_$MODPACK_VERSION.zip\r\n\r\nrm -rf Tekkit_Server_$MODPACK_VERSION.zip\r\n\r\nrm launch.bat\r\n\r\nrm launch.sh\r\n\r\nif [ ! -f server.properties ]; then\r\n    echo -e \"Downloading MC server.properties\"\r\n    curl -o server.properties https:\/\/raw.githubusercontent.com\/parkervcp\/eggs\/master\/game_eggs\/minecraft\/java\/server.properties\r\nfi",
             "container": "alpine:3.9",
             "entrypoint": "ash"
         }

--- a/game_eggs/minecraft/java/technic/tekkit-legends/egg-tekkit-legends.json
+++ b/game_eggs/minecraft/java/technic/tekkit-legends/egg-tekkit-legends.json
@@ -17,7 +17,7 @@
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/ash\r\n# Forge Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\napk update\r\napk add curl\r\n\r\ncd \/mnt\/server\r\n\r\nhttp:\/\/servers.technicpack.net\/Technic\/servers\/tekkit-legends\/Tekkit_Legends_Server_v1.1.1.zip\r\ncurl -sS http:\/\/servers.technicpack.net\/Technic\/servers\/tekkit-legends\/Tekkit_Legends_Server_v$MODPACK_VERSION.zip -o TekkitLegends_$MODPACK_VERSION.zip\r\n\r\nunzip TekkitLegends_$MODPACK_VERSION.zip\r\n\r\nrm -rf TekkitLegends_$MODPACK_VERSION.zip",
+            "script": "#!\/bin\/ash\r\n# Forge Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\napk update\r\napk add curl\r\n\r\ncd \/mnt\/server\r\n\r\nhttps:\/\/servers.technicpack.net\/Technic\/servers\/tekkit-legends\/Tekkit_Legends_Server_v1.1.1.zip\r\ncurl -sS https:\/\/servers.technicpack.net\/Technic\/servers\/tekkit-legends\/Tekkit_Legends_Server_v$MODPACK_VERSION.zip -o TekkitLegends_$MODPACK_VERSION.zip\r\n\r\nunzip TekkitLegends_$MODPACK_VERSION.zip\r\n\r\nrm -rf TekkitLegends_$MODPACK_VERSION.zip",
             "container": "alpine:3.9",
             "entrypoint": "ash"
         }


### PR DESCRIPTION
This PR updates some of the Technic server download URLs to use HTTPS, because HTTP Downloads are no longer supported.

In addition the README was updated to use the new folder structure and include a link to "The 1.12.2 Pack" which was missing.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Did you branch your changes and PR from that branch and not from your master branch?

### Changes to an existing Egg:

1. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [x] Have you tested your Egg changes?
