### PR TITLE
Update fivem_license max input rule to support new key format

### DIFF
--- a/game_eggs/gta/fivem/egg-five-m.json
+++ b/game_eggs/gta/fivem/egg-five-m.json
@@ -35,7 +35,7 @@
             "default_value": "",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string|max:64"
+            "rules": "required|string|max:33"
         },
         {
             "name": "Max Players",

--- a/game_eggs/gta/fivem/egg-five-m.json
+++ b/game_eggs/gta/fivem/egg-five-m.json
@@ -35,7 +35,7 @@
             "default_value": "",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string|max:32"
+            "rules": "required|string|max:64"
         },
         {
             "name": "Max Players",


### PR DESCRIPTION
fix an error with fivem licensekeys that are larger then 32 characters as fivem licensekey length grows