### PR TITLE
fix: sogebot install for sogebot v13+

### DIFF
--- a/bots/twitch/sogebot/egg-soge-bot.json
+++ b/bots/twitch/sogebot/egg-soge-bot.json
@@ -4,38 +4,30 @@
         "version": "PTDL_v1",
         "update_url": null
     },
-    "exported_at": "2021-02-08T16:56:23+01:00",
+    "exported_at": "2021-08-04T05:39:15+03:00",
     "name": "SogeBot",
     "author": "info@goover.de",
     "description": "sogeBot - Free Twitch Bot built on Node.js https:\/\/sogebot.xyz\/",
     "features": null,
     "images": [
-        "quay.io\/parkervcp\/pterodactyl-images:debian_nodejs-14"
+        "quay.io\/parkervcp\/pterodactyl-images:debian_nodejs-16"
     ],
+    "file_denylist": [],
     "startup": "npm start",
     "config": {
         "files": "{\r\n    \".env\": {\r\n        \"parser\": \"properties\",\r\n        \"find\": {\r\n            \"PORT\": \"{{server.build.default.port}}\"\r\n        }\r\n    }\r\n}",
         "startup": "{\r\n    \"done\": \"WebPanel is available at\"\r\n}",
-        "logs": "{\r\n    \"custom\": false,\r\n    \"location\": \"logs\/latest.log\"\r\n}",
-        "stop": "^C"
+        "logs": "{}",
+        "stop": "^^C"
     },
     "scripts": {
         "installation": {
-            "script": "#\/bin\/bash\r\napt -y update\r\napt -y upgrade\r\napt install -y curl unzip sqlite jq wget python3 build-essential\r\nexport NODE_OPTIONS=--max-old-space-size=8192\r\n\r\ncd \/mnt\/server\r\n\r\nrm -fR dest\r\nrm -fR public\r\n\r\n## get release info and download links\r\nLATEST_JSON=$(curl --silent \"https:\/\/api.github.com\/repos\/${GITHUB_PACKAGE}\/releases\/latest\")\r\nRELEASES=$(curl --silent \"https:\/\/api.github.com\/repos\/${GITHUB_PACKAGE}\/releases\")\r\n\r\nif [ -z \"${VERSION}\" ] || [ \"${VERSION}\" == \"latest\" ]; then\r\n    DOWNLOAD_LINK=$(echo ${LATEST_JSON} | jq .assets | jq -r .[].browser_download_url | grep -i ${MATCH})\r\nelse\r\n    VERSION_CHECK=$(echo ${RELEASES} | jq -r --arg VERSION \"${VERSION}\" '.[] | select(.tag_name==$VERSION) | .tag_name')\r\n    if [ \"${VERSION}\" == \"${VERSION_CHECK}\" ]; then\r\n        DOWNLOAD_LINK=$(echo ${RELEASES} | jq -r --arg VERSION \"${VERSION}\" '.[] | select(.tag_name==$VERSION) | .assets[].browser_download_url' | grep -i ${MATCH})\r\n    else\r\n        echo -e \"defaulting to latest release\"\r\n        DOWNLOAD_LINK=$(echo ${LATEST_JSON} | jq .assets | jq -r .[].browser_download_url)\r\n    fi\r\nfi\r\n\r\n#echo $DOWNLOAD_LINK\r\nwget -N $DOWNLOAD_LINK\r\nunzip -o $MATCH-*.zip\r\nrm -fR $MATCH-*.zip\r\n\r\necho \"Installing depencies...\"\r\n\/usr\/local\/bin\/npm ci 2>&1 | tee npmlog.txt\r\n\r\nexit 0",
-            "container": "node:14-buster-slim",
+            "script": "#\/bin\/bash\r\napt -y update\r\napt install -y curl unzip sqlite jq wget python3 build-essential\r\nexport NODE_OPTIONS=--max-old-space-size=8192\r\nMATCH=sogeBot\r\ncd \/mnt\/server\r\n\r\nrm -fR dest\r\nrm -fR public\r\n\r\n## get release info and download links\r\nLATEST_JSON=$(curl --silent \"https:\/\/api.github.com\/repos\/sogehige\/sogeBot\/releases\/latest\")\r\nRELEASES=$(curl --silent \"https:\/\/api.github.com\/repos\/sogehige\/sogeBot\/releases\")\r\n\r\nif [ -z \"${VERSION}\" ] || [ \"${VERSION}\" == \"latest\" ]; then\r\n    DOWNLOAD_LINK=$(echo ${LATEST_JSON} | jq .assets | jq -r .[].browser_download_url | grep -i ${MATCH})\r\nelse\r\n    VERSION_CHECK=$(echo ${RELEASES} | jq -r --arg VERSION \"${VERSION}\" '.[] | select(.tag_name==$VERSION) | .tag_name')\r\n    if [ \"${VERSION}\" == \"${VERSION_CHECK}\" ]; then\r\n        DOWNLOAD_LINK=$(echo ${RELEASES} | jq -r --arg VERSION \"${VERSION}\" '.[] | select(.tag_name==$VERSION) | .assets[].browser_download_url' | grep -i ${MATCH})\r\n    else\r\n        echo -e \"defaulting to latest release\"\r\n        DOWNLOAD_LINK=$(echo ${LATEST_JSON} | jq .assets | jq -r .[].browser_download_url)\r\n    fi\r\nfi\r\n\r\necho -e \"Downloading from $DOWNLOAD_LINK\"\r\nwget -N $DOWNLOAD_LINK\r\nunzip -o $MATCH-*.zip\r\nrm -fR $MATCH-*.zip\r\n\r\necho \"Installing dependencies, this will take some time so sit back and relax...\"\r\n\/usr\/local\/bin\/npm ci 2>&1 | tee npmlog.txt\r\n\r\nexit 0",
+            "container": "node:16-buster-slim",
             "entrypoint": "bash"
         }
     },
     "variables": [
-        {
-            "name": "Github Package",
-            "description": "the Github Package",
-            "env_variable": "GITHUB_PACKAGE",
-            "default_value": "sogehige\/sogeBot",
-            "user_viewable": true,
-            "user_editable": false,
-            "rules": "required|string|max:20"
-        },
         {
             "name": "Version",
             "description": "Choose Version, you want to install. Default: Latest",
@@ -43,15 +35,6 @@
             "default_value": "latest",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string|max:20"
-        },
-        {
-            "name": "Filename",
-            "description": "Filename",
-            "env_variable": "MATCH",
-            "default_value": "sogeBot",
-            "user_viewable": true,
-            "user_editable": false,
             "rules": "required|string|max:20"
         }
     ]


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

### Changes to an existing Egg:

1. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [x] Have you tested your Egg changes?

Sogebot now requires Nodejs 16 to build and run and is not backward compatible with previous versions. Didn't add backwards compatibility because of this, but we might have to add version detection for building similar to Spigot?

Migrated MATCH and PACKAGE variables into the install script itself to make it cleaner. They're not something the end user needs to see.

resolves #1271