### PR TITLE
Info to get the new server jars to work

### DIFF
--- a/game_eggs/minecraft/java/forge/curseforge-generic/egg-curseforge-generic.json
+++ b/game_eggs/minecraft/java/forge/curseforge-generic/egg-curseforge-generic.json
@@ -16,7 +16,7 @@
         "ghcr.io\/pterodactyl\/yolks:java_16"
     ],
     "file_denylist": [],
-    "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar server.jar",
+    "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar *server.jar",
     "config": {
         "files": "{\r\n    \"server.properties\": {\r\n        \"parser\": \"properties\",\r\n        \"find\": {\r\n            \"server-ip\": \"0.0.0.0\",\r\n            \"server-port\": \"{{server.build.default.port}}\",\r\n            \"query.port\": \"{{server.build.default.port}}\"\r\n        }\r\n    }\r\n}",
         "startup": "{\r\n    \"done\": \")! For help, type \",\r\n    \"userInteraction\": [\r\n        \"Go to eula.txt for more info.\"\r\n    ]\r\n}",


### PR DESCRIPTION
Tried with modpack 416929
I was only able to use java 8 to get this specific modpack to work, and i found some info that javaFX is needed to get this to work, and javaFX is bundled with java 8.
Maybe there is a reason to bundle or make JavaFX an optional download with the CurseForge egg.
Also added the star in front of the server.jar to make the starts easier.

### All Submissions:

* [ X] Have you followed the guidelines in our Contributing document?
* [ X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [ X] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

### Changes to an existing Egg:

1. [ x] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [ x] Have you tested your Egg changes?
