### PR TITLE
Fixed NoBattlEye being Incorrectly Setup

### DIFF
--- a/game_eggs/steamcmd_servers/ark_survival_evolved/egg-ark--survival-evolved.json
+++ b/game_eggs/steamcmd_servers/ark_survival_evolved/egg-ark--survival-evolved.json
@@ -13,7 +13,7 @@
         "quay.io\/parkervcp\/pterodactyl-images:debian_source"
     ],
     "file_denylist": [],
-    "startup": "rmv() { echo -e \"stopping server\"; rcon -t rcon -a 127.0.0.1:${RCON_PORT} -p ${ARK_ADMIN_PASSWORD} -c saveworld && rcon -a 127.0.0.1:${RCON_PORT} -p ${ARK_ADMIN_PASSWORD} -c DoExit; }; trap rmv 15; cd ShooterGame\/Binaries\/Linux && .\/ShooterGameServer {{SERVER_MAP}}?listen?SessionName=\"{{SESSION_NAME}}\"?ServerPassword={{ARK_PASSWORD}}?ServerAdminPassword={{ARK_ADMIN_PASSWORD}}?Port={{SERVER_PORT}}?RCONPort={{RCON_PORT}}?QueryPort={{QUERY_PORT}}?RCONEnabled=True$( [ \"$BATTLE_EYE\" == \"0\" ] || printf %s '?-NoBattlEye' ) -server {{ARGS}} -log & until echo \"waiting for rcon connection...\"; rcon -t rcon -a 127.0.0.1:${RCON_PORT} -p ${ARK_ADMIN_PASSWORD}; do sleep 5; done",
+    "startup": "rmv() { echo -e \"stopping server\"; rcon -t rcon -a 127.0.0.1:${RCON_PORT} -p ${ARK_ADMIN_PASSWORD} -c saveworld && rcon -a 127.0.0.1:${RCON_PORT} -p ${ARK_ADMIN_PASSWORD} -c DoExit; }; trap rmv 15; cd ShooterGame\/Binaries\/Linux && .\/ShooterGameServer {{SERVER_MAP}}?listen?SessionName=\"{{SESSION_NAME}}\"?ServerPassword={{ARK_PASSWORD}}?ServerAdminPassword={{ARK_ADMIN_PASSWORD}}?Port={{SERVER_PORT}}?RCONPort={{RCON_PORT}}?QueryPort={{QUERY_PORT}}?RCONEnabled=True$( [ \"$BATTLE_EYE\" != \"0\" ] || printf %s ' -NoBattlEye' ) -server {{ARGS}} -log & until echo \"waiting for rcon connection...\"; rcon -t rcon -a 127.0.0.1:${RCON_PORT} -p ${ARK_ADMIN_PASSWORD}; do sleep 5; done",
     "config": {
         "files": "{}",
         "startup": "{\r\n    \"done\": \"Waiting commands for 127.0.0.1:\"\r\n}",


### PR DESCRIPTION
the NoBattlEye launch option should have a space before and after it, as it is a launch option not one of the '?server?start?perameter' things. Also, the entire variable is inversed as setting it to '1' should cause '-NoBattlEye' to NOT be printed.

### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [ ] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Server Submissions:

1. [ ] Does your submission pass tests (server is connectable)?
2. [ ] Does your server use a custom docker image?
    * [ ] Have you tried to use a generic image?
    * [ ] Did you PR the necessary changes to make it work?
3. [ ] Have you added the server to the main README.md?
4. [ ] Have you added a unique README.md for the server you are adding?

### Changes to an existing Egg:

1. [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [ ] Have you tested your Egg changes?
