### PR TITLE
Pocketmine Egg - Switch Version Variable to not editeble and not shown, because Pocket…

### DIFF
--- a/game_eggs/minecraft/bedrock/pocketmine_mp/egg-pocketmine-m-p.json
+++ b/game_eggs/minecraft/bedrock/pocketmine_mp/egg-pocketmine-m-p.json
@@ -33,8 +33,8 @@
             "description": "Version from Github",
             "env_variable": "VERSION",
             "default_value": "latest",
-            "user_viewable": true,
-            "user_editable": true,
+            "user_viewable": false,
+            "user_editable": false,
             "rules": "required|string|max:20"
         },
         {


### PR DESCRIPTION
…mine can only be used in latest Version. The Egg can't handle all needed PHP Versions from older eggs

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [ ] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

### Changes to an existing Egg:

1. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [x] Have you tested your Egg changes?
