### PR TITLE
Satisfactory Port Visibility Hotfix

### DIFF
--- a/game_eggs/steamcmd_servers/satisfactory/egg-satisfactory.json
+++ b/game_eggs/steamcmd_servers/satisfactory/egg-satisfactory.json
@@ -32,7 +32,7 @@
             "description": "This is the port that your clients will type in and use to connect to the lobby (not the game world). Ensure this port matches your externally forwarded port, and is distanced from other running Satisfactory servers in Pterodactyl (increments of 100 are recommended). This is also true for the Primary\/Game Port!",
             "env_variable": "QUERY_PORT",
             "default_value": "15777",
-            "user_viewable": false,
+            "user_viewable": true,
             "user_editable": false,
             "rules": "required|integer|between:1024,65536"
         },
@@ -41,7 +41,7 @@
             "description": "This port provides a lightweight way for clients to contact a server and interact with it without committing to a normal game connection (likely used for client administration). Ensure this port matches your externally forwarded port, and is distanced from other running Satisfactory servers in Pterodactyl (increments of 100 are recommended).",
             "env_variable": "BEACON_PORT",
             "default_value": "15000",
-            "user_viewable": false,
+            "user_viewable": true,
             "user_editable": false,
             "rules": "required|integer|between:1024,65536"
         },


### PR DESCRIPTION
### Hotfix to make the Query and Beacon ports visible to the end user.

> I initially wanted ports that were not relevant to the end user (like the Game and Beacon port variables) not visible. But with Game moving to Primary and Query moving back to a variable in the initial PR, and because clients need to know the Query port to connect to the server, it is now necessary that these ports be visible.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Did you branch your changes and PR from that branch and not from your master branch?

### Changes to an existing Egg:

1. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [x] Have you tested your Egg changes?
