### PR TITLE
[Satisfactory] 0.5.0.6 Boot Crash Hotfix & Explicit Game Port Declaration

### DIFF
--- a/game_eggs/steamcmd_servers/satisfactory/egg-satisfactory.json
+++ b/game_eggs/steamcmd_servers/satisfactory/egg-satisfactory.json
@@ -12,7 +12,7 @@
         "ghcr.io\/pterodactyl\/games:source"
     ],
     "file_denylist": [],
-    "startup": ".\/Engine\/Binaries\/Linux\/UE4Server-Linux-Shipping FactoryGame -Port={{SERVER_PORT}} -ServerQueryPort={{QUERY_PORT}} -BeaconPort={{BEACON_PORT}}",
+    "startup": ".\/Engine\/Binaries\/Linux\/UE4Server-Linux-Shipping FactoryGame ?listen -Port={{SERVER_PORT}} -ServerQueryPort={{QUERY_PORT}} -BeaconPort={{BEACON_PORT}} -multihome=0.0.0.0",
     "config": {
         "files": "{\r\n    \"FactoryGame\/Saved\/Config\/LinuxServer\/Game.ini\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"MaxPlayers\": \"MaxPlayers={{server.build.env.MAX_PLAYERS}}\"\r\n        }\r\n    }\r\n}",
         "startup": "{\r\n    \"done\": \"Engine Initialization\"\r\n}",


### PR DESCRIPTION
- Adds the newly discovered `-multihome` flag to fix 0.5.0.6 update's IPv6 related issue, where the IP binds to IPv6 by default, causing a crash on boot. Server will now bind to IPv4 by default. As this is a hotfix, IPv6's possible support will be investigated at a later date.
- Adds the newly discovered `?listen` flag to the `-Port` flag to explicitly declare the port. This will prevent the server from possibly auto-incrementing the port if, for whatever reason, it thinks there's another Satisfactory server present in the same container.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Did you branch your changes and PR from that branch and not from your master branch?

### Changes to an existing Egg:

1. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [x] Have you tested your Egg changes?
