### PR TITLE
feat(fabric): add option to select Fabric version

### DIFF
--- a/game_eggs/minecraft/java/fabric/egg-fabric.json
+++ b/game_eggs/minecraft/java/fabric/egg-fabric.json
@@ -64,7 +64,7 @@
             "name": "Fabric Loader Version",
             "description": "The version of Fabric Loader to install.",
             "env_variable": "LOADER_VERSION",
-            "default_value": "stable",
+            "default_value": "latest",
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|string|between:3,15"

--- a/game_eggs/minecraft/java/fabric/egg-fabric.json
+++ b/game_eggs/minecraft/java/fabric/egg-fabric.json
@@ -63,7 +63,7 @@
             "name": "Fabric Loader Version",
             "description": "The version of Fabric Loader to install.",
             "env_variable": "LOADER_VERSION",
-            "default_value": "stable",
+            "default_value": "latest",
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|string|between:3,15"

--- a/game_eggs/minecraft/java/fabric/egg-fabric.json
+++ b/game_eggs/minecraft/java/fabric/egg-fabric.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v1",
         "update_url": null
     },
-    "exported_at": "2021-06-14T21:30:32+03:00",
+    "exported_at": "2021-11-04T15:17:39+00:00",
     "name": "Fabric",
     "author": "accounts@bofanodes.io",
     "description": "Fabric is a modular modding toolchain targeting Minecraft 1.14 and above, including snapshots.",
@@ -27,7 +27,7 @@
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/bash\r\n# Fabric MC Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\napt update\r\napt install -y curl jq unzip dos2unix wget\r\nmkdir -p \/mnt\/server\r\ncd \/mnt\/server\r\n\r\n# Enable snapshots\r\nif [ -z \"$MC_VERSION\" ] || [ \"$MC_VERSION\" == \"latest\" ]; then\r\n  MC_VERSION=$(curl -sSL https:\/\/meta.fabricmc.net\/v2\/versions\/game | jq -r '.[] | select(.stable== true )|.version' | head -n1)\r\nelif [ \"$MC_VERSION\" == \"snapshot\" ]; then\r\n  MC_VERSION=$(curl -sSL https:\/\/meta.fabricmc.net\/v2\/versions\/game | jq -r '.[] | select(.stable== false )|.version' | head -n1)\r\nfi\r\n\r\nif [ -z \"$FABRIC_VERSION\" ] || [ \"$FABRIC_VERSION\" == \"latest\" ]; then\r\n  FABRIC_VERSION=$(curl -sSL https:\/\/meta.fabricmc.net\/v2\/versions\/installer | jq -r '.[0].version')\r\nfi\r\nwget -O fabric-installer.jar https:\/\/maven.fabricmc.net\/net\/fabricmc\/fabric-installer\/$FABRIC_VERSION\/fabric-installer-$FABRIC_VERSION.jar\r\njava -jar fabric-installer.jar server -mcversion $MC_VERSION -downloadMinecraft\r\necho -e \"Install Complete\"",
+            "script": "#!\/bin\/bash\r\n# Fabric MC Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\napt update\r\napt install -y curl jq unzip dos2unix wget\r\nmkdir -p \/mnt\/server\r\ncd \/mnt\/server\r\n\r\n# Enable snapshots\r\nif [ -z \"$MC_VERSION\" ] || [ \"$MC_VERSION\" == \"latest\" ]; then\r\n  MC_VERSION=$(curl -sSL https:\/\/meta.fabricmc.net\/v2\/versions\/game | jq -r '.[] | select(.stable== true )|.version' | head -n1)\r\nelif [ \"$MC_VERSION\" == \"snapshot\" ]; then\r\n  MC_VERSION=$(curl -sSL https:\/\/meta.fabricmc.net\/v2\/versions\/game | jq -r '.[] | select(.stable== false )|.version' | head -n1)\r\nfi\r\n\r\nif [ -z \"$FABRIC_VERSION\" ] || [ \"$FABRIC_VERSION\" == \"latest\" ]; then\r\n  FABRIC_VERSION=$(curl -sSL https:\/\/meta.fabricmc.net\/v2\/versions\/installer | jq -r '.[0].version')\r\nfi\r\n\r\nif [ -z \"$LOADER_VERSION\" ] || [ \"$LOADER_VERSION\" == \"latest\" ]; then\r\n  LOADER_VERSION=$(curl -sSL https:\/\/meta.fabricmc.net\/v2\/versions\/loader | jq -r '.[] | select(.stable== true )|.version' | head -n1)\r\nelif [ \"$LOADER_VERSION\" == \"snapshot\" ]; then\r\n  LOADER_VERSION=$(curl -sSL https:\/\/meta.fabricmc.net\/v2\/versions\/loader | jq -r '.[] | select(.stable== false )|.version' | head -n1)\r\nfi\r\n\r\nwget -O fabric-installer.jar https:\/\/maven.fabricmc.net\/net\/fabricmc\/fabric-installer\/$FABRIC_VERSION\/fabric-installer-$FABRIC_VERSION.jar\r\njava -jar fabric-installer.jar server -mcversion $MC_VERSION -loader $LOADER_VERSION -downloadMinecraft\r\necho -e \"Install Complete\"",
             "container": "openjdk:11-jdk-slim",
             "entrypoint": "bash"
         }
@@ -56,6 +56,15 @@
             "description": "The version of Fabric to install.",
             "env_variable": "FABRIC_VERSION",
             "default_value": "latest",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string|between:3,15"
+        },
+        {
+            "name": "Fabric Loader Version",
+            "description": "The version of Fabric Loader to install.",
+            "env_variable": "LOADER_VERSION",
+            "default_value": "stable",
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|string|between:3,15"

--- a/game_eggs/minecraft/java/fabric/egg-fabric.json
+++ b/game_eggs/minecraft/java/fabric/egg-fabric.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v1",
         "update_url": null
     },
-    "exported_at": "2021-11-04T15:17:39+00:00",
+    "exported_at": "2021-11-06T19:02:28+00:00",
     "name": "Fabric",
     "author": "accounts@bofanodes.io",
     "description": "Fabric is a modular modding toolchain targeting Minecraft 1.14 and above, including snapshots.",
@@ -12,9 +12,8 @@
         "eula"
     ],
     "images": [
-        "ghcr.io\/pterodactyl\/yolks:java_11",
         "ghcr.io\/pterodactyl\/yolks:java_8",
-        "ghcr.io\/pterodactyl\/yolks:java_14",
+        "ghcr.io\/pterodactyl\/yolks:java_11",
         "ghcr.io\/pterodactyl\/yolks:java_16"
     ],
     "file_denylist": [],
@@ -64,7 +63,7 @@
             "name": "Fabric Loader Version",
             "description": "The version of Fabric Loader to install.",
             "env_variable": "LOADER_VERSION",
-            "default_value": "latest",
+            "default_value": "stable",
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|string|between:3,15"


### PR DESCRIPTION
Make it possible to choose a Fabric Loader Version

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:
  
### Changes to an existing Egg:

1. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [x] Have you tested your Egg changes?

This PR makes it possible to choose a Loader version in the Fabric egg, which would be very useful because recently the latest stable Loader version (chosen automatically by the installer, if no version is specified using `-loader`) stopped working with the latest snapshot Minecraft versions.