### PR TITLE
Pocketmine: Add debug messages, fix PHP extension path and change install image

### DIFF
--- a/game_eggs/minecraft/bedrock/pocketmine_mp/egg-pocketmine-m-p.json
+++ b/game_eggs/minecraft/bedrock/pocketmine_mp/egg-pocketmine-m-p.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v1",
         "update_url": null
     },
-    "exported_at": "2021-10-24T16:47:50+02:00",
+    "exported_at": "2021-11-18T21:36:31+00:00",
     "name": "PocketmineMP",
     "author": "info@swisscrafting.ch",
     "description": "Pocketmine Egg\r\nby onekintaro from swisscrafting.ch\r\nwith the nice help from #eggs Channel on Pterodactyl-Discord :)",
@@ -16,14 +16,14 @@
     "startup": ".\/bin\/php7\/bin\/php .\/PocketMine-MP.phar --no-wizard --disable-ansi",
     "config": {
         "files": "{\r\n    \"server.properties\": {\r\n        \"parser\": \"properties\",\r\n        \"find\": {\r\n            \"server-ip\": \"0.0.0.0\",\r\n            \"enable-query\": \"true\",\r\n            \"server-port\": \"{{server.build.default.port}}\",\r\n            \"query.port\": \"{{server.build.default.port}}\"\r\n        }\r\n    }\r\n}",
-        "startup": "{\r\n    \"done\": \")! For help, type \",\r\n    \"userInteraction\": [\r\n        \"Go to eula.txt for more info.\"\r\n    ]\r\n}",
-        "logs": "{\r\n    \"custom\": false,\r\n    \"location\": \"server.log\"\r\n}",
+        "startup": "{\r\n    \"done\": \")! For help, type \"\r\n}",
+        "logs": "{}",
         "stop": "stop"
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/bash\r\n\r\napt update\r\napt install -y curl jq\r\n\r\ncd \/mnt\/server\r\n\r\n## get release info and download links\r\nLATEST_JSON=$(curl --silent \"https:\/\/api.github.com\/repos\/${GITHUB_PACKAGE}\/releases\/latest\")\r\nRELEASES=$(curl --silent \"https:\/\/api.github.com\/repos\/${GITHUB_PACKAGE}\/releases\")\r\n\r\nDOWNLOAD_LINK=$(echo ${LATEST_JSON} | jq .assets | jq -r .[].browser_download_url | grep -i ${MATCH})\r\n\r\n## this is a simple script to validate a download url actaully exists\r\n\r\nif [ ! -z \"${DOWNLOAD_URL}\"]; then \r\n    if curl --output \/dev\/null --silent --head --fail ${DOWNLOAD_URL}; then\r\n        echo -e \"link is valid. setting download link to ${DOWNLOAD_URL}\"\r\n        DOWNLOAD_LINK=${DOWNLOAD_URL}\r\n    else        \r\n        echo -e \"link is invalid closing out\"\r\n        exit 2\r\n    fi\r\nfi\r\n\r\ncurl -sSL ${DOWNLOAD_LINK} > PocketMine-MP.phar\r\n\r\necho -e \"\\n downloading latest php build from pocketmine\"\r\ncurl -sSL -o php.binary.tar.gz https:\/\/jenkins.pmmp.io\/job\/PHP-8.0-Aggregate\/lastStableBuild\/artifact\/PHP-8.0-Linux-x86_64.tar.gz\r\n\r\necho -e \"\\n getting default server.properties\"\r\ncurl -sSL https:\/\/raw.githubusercontent.com\/parkervcp\/eggs\/master\/game_eggs\/minecraft\/bedrock\/pocketmine_mp\/server.properties > server.properties\r\n\r\necho -e \"\\n unpacking php binaries\"\r\ntar -xzvf php.binary.tar.gz\r\n\r\necho -e \"\\n removing php packages\"\r\nrm -rf \/mnt\/server\/php.binary.tar.gz\r\n\r\necho -e \"\\n creating files and folders\"\r\ntouch banned-ips.txt banned-players.txt ops.txt white-list.txt server.log\r\nmkdir -p players worlds plugins resource_packs",
-            "container": "debian:buster-slim",
+            "script": "#!\/bin\/bash\r\n\r\n# This is already installed in our Script container image. Leaving it here for future reference | apt install -y curl jq\r\n\r\ncd \/mnt\/server\r\n\r\n## get release info and download links\r\nLATEST_JSON=$(curl --silent \"https:\/\/api.github.com\/repos\/${GITHUB_PACKAGE}\/releases\/latest\")\r\nRELEASES=$(curl --silent \"https:\/\/api.github.com\/repos\/${GITHUB_PACKAGE}\/releases\")\r\n\r\nDOWNLOAD_LINK=$(echo ${LATEST_JSON} | jq .assets | jq -r .[].browser_download_url | grep -i ${MATCH})\r\n\r\n## this is a simple script to validate a download url actually exists\r\n\r\nif [ ! -z \"${DOWNLOAD_URL}\"]; then \r\n    if curl --output \/dev\/null --silent --head --fail ${DOWNLOAD_URL}; then\r\n        echo -e \"link is valid. setting download link to ${DOWNLOAD_URL}\"\r\n        DOWNLOAD_LINK=${DOWNLOAD_URL}\r\n    else        \r\n        echo -e \"link is invalid closing out\"\r\n        exit 2\r\n    fi\r\nfi\r\n\r\necho -e \"performing curl -sSL ${DOWNLOAD_LINK}\"\r\ncurl -sSL ${DOWNLOAD_LINK} > PocketMine-MP.phar\r\n\r\necho -e \"\\n downloading latest php build from pocketmine from https:\/\/jenkins.pmmp.io\/job\/PHP-8.0-Aggregate\/lastStableBuild\/artifact\/PHP-8.0-Linux-x86_64.tar.gz\"\r\ncurl -sSL -o php.binary.tar.gz https:\/\/jenkins.pmmp.io\/job\/PHP-8.0-Aggregate\/lastStableBuild\/artifact\/PHP-8.0-Linux-x86_64.tar.gz\r\n\r\nif [ ! -f server.properties ]; then\r\n    echo -e \"\\n downloading default server.properties\"\r\n    curl -sSL https:\/\/raw.githubusercontent.com\/parkervcp\/eggs\/master\/game_eggs\/minecraft\/bedrock\/pocketmine_mp\/server.properties > server.properties\r\nfi\r\n\r\necho -e \"\\n unpacking php binaries\"\r\ntar -xzvf php.binary.tar.gz\r\n\r\necho -e \"\\n removing php packages\"\r\nrm -rf \/mnt\/server\/php.binary.tar.gz\r\n\r\necho -e \"\\n configuring PHP extensions library directory\"\r\nEXTENSION_DIR=$(find \"bin\" -name *debug-zts*)\r\ngrep -q '^extension_dir' bin\/php7\/bin\/php.ini && sed -i'bak' \"s{^extension_dir=.*{extension_dir=\\\"$EXTENSION_DIR\\\"{\" bin\/php7\/bin\/php.ini || echo \"extension_dir=\\\"$EXTENSION_DIR\\\"\" >> bin\/php7\/bin\/php.ini\r\n\r\necho -e \"\\n creating files and folders\"\r\ntouch banned-ips.txt banned-players.txt ops.txt white-list.txt server.log\r\nmkdir -p players worlds plugins resource_packs",
+            "container": "ghcr.io\/parkervcp\/installers:debian",
             "entrypoint": "bash"
         }
     },


### PR DESCRIPTION
Add debug messages for debugging when users complain. Do not overwrite `server.properties` if it exists.

Correctly configure PHP `extensions_dir`to fix issues with loading extensions like opcache.so. Change install image to our installer for faster installation.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

### Changes to an existing Egg:

1. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [x] Have you tested your Egg changes?
