### PR TITLE
refactor Spigot to support minor versions, 1.18+, and new Java images

### DIFF
--- a/game_eggs/minecraft/java/spigot/egg-spigot.json
+++ b/game_eggs/minecraft/java/spigot/egg-spigot.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v1",
         "update_url": null
     },
-    "exported_at": "2021-10-05T15:36:31-04:00",
+    "exported_at": "2021-11-27T03:38:30+00:00",
     "name": "Spigot",
     "author": "support@pterodactyl.io",
     "description": "Spigot is the most widely-used modded Minecraft server software in the world. It powers many of the top Minecraft server networks around to ensure they can cope with their huge player base and ensure the satisfaction of their players. Spigot works by reducing and eliminating many causes of lag, as well as adding in handy features and settings that help make your job of server administration easier.",
@@ -28,7 +28,7 @@
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/bash\r\n# Spigot Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\napt update\r\napt install -y curl wget git openssl  apt-transport-https gnupg software-properties-common\r\nwget -qO - https:\/\/adoptopenjdk.jfrog.io\/adoptopenjdk\/api\/gpg\/key\/public | apt-key add -\r\nadd-apt-repository --yes https:\/\/adoptopenjdk.jfrog.io\/adoptopenjdk\/deb\/\r\napt update\r\n\r\nmkdir -p \/usr\/share\/man\/man1\r\n\r\nif [[ $DL_VERSION == *\"1.17.\"* || $DL_VERSION == *\"1.18.\"*  || $DL_VERSION == *\"1.19.\"* || $DL_VERSION == \"latest\" ]]; then\r\n    apt install -y adoptopenjdk-16-hotspot\r\nelse\r\n    apt install -y adoptopenjdk-8-hotspot\r\nfi\r\n\r\n## Only download if a path is provided, otherwise continue.\r\nif [ ! -z \"${DL_PATH}\" ]; then\r\n    cd \/mnt\/server\r\n    MODIFIED_DOWNLOAD=`eval echo $(echo ${DL_PATH} | sed -e 's\/{{\/${\/g' -e 's\/}}\/}\/g')`\r\n    curl -sSL -o ${SERVER_JARFILE} ${MODIFIED_DOWNLOAD}\r\nelse\r\n    mkdir -p \/srv\/\r\n    cd \/srv\/\r\n    wget https:\/\/hub.spigotmc.org\/jenkins\/job\/BuildTools\/lastSuccessfulBuild\/artifact\/target\/BuildTools.jar\r\n    java -Xms${SERVER_MEMORY}M -jar BuildTools.jar --rev ${DL_VERSION}\r\n    mv spigot-*.jar \/mnt\/server\/${SERVER_JARFILE}\r\nfi",
+            "script": "#!\/bin\/bash\r\n# Spigot Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\napt update\r\napt install -y curl wget git openssl apt-transport-https gnupg software-properties-common\r\nwget -qO - https:\/\/adoptopenjdk.jfrog.io\/adoptopenjdk\/api\/gpg\/key\/public | apt-key add -\r\nadd-apt-repository --yes https:\/\/adoptopenjdk.jfrog.io\/adoptopenjdk\/deb\/\r\napt update\r\n\r\nmkdir -p \/usr\/share\/man\/man1\r\n\r\nif [[ $DL_VERSION =~ ^1\\.(18|19|20|21|22) || $DL_VERSION == \"latest\" ]]; then\r\n    apt install -y adoptopenjdk-17-hotspot\r\nelif [[ $DL_VERSION =~ ^1\\.(17) ]]; then\r\n    apt install -y adoptopenjdk-16-hotspot\r\nelse\r\n    apt install -y adoptopenjdk-8-hotspot\r\nfi\r\n\r\n## Only download if a path is provided, otherwise continue.\r\nif [ ! -z \"${DL_PATH}\" ]; then\r\n    cd \/mnt\/server\r\n    MODIFIED_DOWNLOAD=`eval echo $(echo ${DL_PATH} | sed -e 's\/{{\/${\/g' -e 's\/}}\/}\/g')`\r\n    curl -sSL -o ${SERVER_JARFILE} ${MODIFIED_DOWNLOAD}\r\nelse\r\n    mkdir -p \/srv\/\r\n    cd \/srv\/\r\n    wget https:\/\/hub.spigotmc.org\/jenkins\/job\/BuildTools\/lastSuccessfulBuild\/artifact\/target\/BuildTools.jar\r\n    java -Xms${SERVER_MEMORY}M -jar BuildTools.jar --rev ${DL_VERSION}\r\n    mv spigot-*.jar \/mnt\/server\/${SERVER_JARFILE}\r\nfi",
             "container": "debian:buster-slim",
             "entrypoint": "bash"
         }

--- a/game_eggs/minecraft/java/spigot/egg-spigot.json
+++ b/game_eggs/minecraft/java/spigot/egg-spigot.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v1",
         "update_url": null
     },
-    "exported_at": "2021-11-27T03:38:30+00:00",
+    "exported_at": "2021-11-27T05:14:42+00:00",
     "name": "Spigot",
     "author": "support@pterodactyl.io",
     "description": "Spigot is the most widely-used modded Minecraft server software in the world. It powers many of the top Minecraft server networks around to ensure they can cope with their huge player base and ensure the satisfaction of their players. Spigot works by reducing and eliminating many causes of lag, as well as adding in handy features and settings that help make your job of server administration easier.",
@@ -28,8 +28,8 @@
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/bash\r\n# Spigot Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\napt update\r\napt install -y curl wget git openssl apt-transport-https gnupg software-properties-common\r\nwget -qO - https:\/\/adoptopenjdk.jfrog.io\/adoptopenjdk\/api\/gpg\/key\/public | apt-key add -\r\nadd-apt-repository --yes https:\/\/adoptopenjdk.jfrog.io\/adoptopenjdk\/deb\/\r\napt update\r\n\r\nmkdir -p \/usr\/share\/man\/man1\r\n\r\nif [[ $DL_VERSION =~ ^1\\.(18|19|20|21|22) || $DL_VERSION == \"latest\" ]]; then\r\n    apt install -y adoptopenjdk-17-hotspot\r\nelif [[ $DL_VERSION =~ ^1\\.(17) ]]; then\r\n    apt install -y adoptopenjdk-16-hotspot\r\nelse\r\n    apt install -y adoptopenjdk-8-hotspot\r\nfi\r\n\r\n## Only download if a path is provided, otherwise continue.\r\nif [ ! -z \"${DL_PATH}\" ]; then\r\n    cd \/mnt\/server\r\n    MODIFIED_DOWNLOAD=`eval echo $(echo ${DL_PATH} | sed -e 's\/{{\/${\/g' -e 's\/}}\/}\/g')`\r\n    curl -sSL -o ${SERVER_JARFILE} ${MODIFIED_DOWNLOAD}\r\nelse\r\n    mkdir -p \/srv\/\r\n    cd \/srv\/\r\n    wget https:\/\/hub.spigotmc.org\/jenkins\/job\/BuildTools\/lastSuccessfulBuild\/artifact\/target\/BuildTools.jar\r\n    java -Xms${SERVER_MEMORY}M -jar BuildTools.jar --rev ${DL_VERSION}\r\n    mv spigot-*.jar \/mnt\/server\/${SERVER_JARFILE}\r\nfi",
-            "container": "debian:buster-slim",
+            "script": "#!\/bin\/bash\r\n# Spigot Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\n\r\nmkdir -p \/usr\/share\/man\/man1\r\n\r\nfunction install_java() {\r\n  curl -L $1 -o java.tar.gz\r\n  tar xzf java.tar.gz\r\n  export PATH=$PWD\/$2\/bin:$PATH\r\n  java -version\r\n}\r\n\r\nfunction build_spigot()\r\n{\r\n  java -Xms$1M -jar BuildTools.jar --rev ${DL_VERSION} || { echo -e \"\\n install failed! Attempted to install ${DL_VERSION} with memory of ${SERVER_MEMORY} and Java version of:\"; java -version; exit 1; }\r\n}\r\n\r\n# Detect the required Java version for building Spigot. Currently temurin only provides archives of their releases, and adoptopenjdk is deprecated. Update this when packages are released.\r\nif [[ $DL_VERSION =~ ^1\\.(18|19|20|21|22|23) || $DL_VERSION == \"latest\" ]]; then\r\n    install_java \"https:\/\/github.com\/adoptium\/temurin17-binaries\/releases\/download\/jdk-17.0.1%2B12\/OpenJDK17U-jdk_x64_linux_hotspot_17.0.1_12.tar.gz\" jdk-17.0.1+12\r\nelif [[ $DL_VERSION =~ ^1\\.(17) ]]; then\r\n    install_java \"https:\/\/github.com\/adoptium\/temurin16-binaries\/releases\/download\/jdk-16.0.2%2B7\/OpenJDK16U-jdk_x64_linux_hotspot_16.0.2_7.tar.gz\" jdk-16.0.2+7\r\nelse\r\n    install_java \"https:\/\/github.com\/adoptium\/temurin8-binaries\/releases\/download\/jdk8u312-b07\/OpenJDK8U-jdk_x64_linux_hotspot_8u312b07.tar.gz\" jdk8u312-b07\r\nfi\r\n\r\n\r\n## Only download if a path is provided, otherwise continue.\r\nif [ ! -z \"${DL_PATH}\" ]; then\r\n    cd \/mnt\/server\r\n    MODIFIED_DOWNLOAD=`eval echo $(echo ${DL_PATH} | sed -e 's\/{{\/${\/g' -e 's\/}}\/}\/g')`\r\n    echo -e \"Using custom provided download link ${MODIFIED_DOWNLOAD}\"\r\n    curl -L ${MODIFIED_DOWNLOAD} -o ${SERVER_JARFILE}\r\nelse\r\n    mkdir -p \/srv\/\r\n    cd \/srv\/\r\n    curl -L https:\/\/hub.spigotmc.org\/jenkins\/job\/BuildTools\/lastSuccessfulBuild\/artifact\/target\/BuildTools.jar -o BuildTools.jar\r\n\r\n    # Force the minimum Wings install container memory should someone provide less or 0 as it will break the Java build process\r\n    if [ $SERVER_MEMORY -lt 1024 ]; then\r\n        echo -e \"Do not use 0 for memory with Java applications. Defaulting to 1024MB.\\n WARNING! 1024MB might not be enough to build 1.17+ releases.\"\r\n        SERVER_MEMORY=1024\r\n        build_spigot ${SERVER_MEMORY}\r\n    else\r\n        build_spigot ${SERVER_MEMORY}\r\n    fi\r\n    mv spigot-*.jar \/mnt\/server\/${SERVER_JARFILE}\r\nfi",
+            "container": "ghcr.io\/parkervcp\/installers:debian",
             "entrypoint": "bash"
         }
     },
@@ -54,12 +54,12 @@
         },
         {
             "name": "Spigot Version",
-            "description": "The version of Spigot to download (using the --rev tag). Use \"latest\" for latest.",
+            "description": "The version of Spigot to download (using the --rev tag from https:\/\/hub.spigotmc.org\/versions). Use \"latest\" for latest.",
             "env_variable": "DL_VERSION",
             "default_value": "latest",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string|between:3,7"
+            "rules": "required|string|between:3,10"
         }
     ]
 }


### PR DESCRIPTION
- add support for Spigot 1.18 - 1.23 including snapshots that should future proof it
- change install image and remove packages from installation since our install image contains them all
- add troubleshooting steps and messages should install fail
- use temurin Java images for building since adoptopenjdk is deprecated and doesn't have 17
- overwrite used memory for building to 1024 if less than 1024 is used . Wings allocates minimum of 1024MB memory, however, it's not enough to build 1.17+



### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

### Changes to an existing Egg:

1. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [x] Have you tested your Egg changes?
