### PR TITLE
chore: update Java images for default Minecraft eggs

### DIFF
--- a/stock_eggs/minecraft/egg-bungeecord.json
+++ b/stock_eggs/minecraft/egg-bungeecord.json
@@ -3,14 +3,16 @@
     "meta": {
         "version": "PTDL_v1"
     },
-    "exported_at": "2020-10-19T23:22:26+00:00",
+    "exported_at": "2021-11-29T23:22:26+00:00",
     "name": "Bungeecord",
     "author": "support@pterodactyl.io",
     "description": "For a long time, Minecraft server owners have had a dream that encompasses a free, easy, and reliable way to connect multiple Minecraft servers together. BungeeCord is the answer to said dream. Whether you are a small server wishing to string multiple game-modes together, or the owner of the ShotBow Network, BungeeCord is the ideal solution for you. With the help of BungeeCord, you will be able to unlock your community's full potential.",
     "image": "quay.io\/pterodactyl\/core:java",
     "images": [
-        "quay.io\/pterodactyl\/core:java",
-        "quay.io\/pterodactyl\/core:java-11"
+        "ghcr.io\/pterodactyl\/yolks:java_8",
+        "ghcr.io\/pterodactyl\/yolks:java_11",
+        "ghcr.io\/pterodactyl\/yolks:java_16",
+        "ghcr.io\/pterodactyl\/yolks:java_17"
     ],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",
     "config": {

--- a/stock_eggs/minecraft/egg-paper.json
+++ b/stock_eggs/minecraft/egg-paper.json
@@ -3,7 +3,7 @@
     "meta": {
         "version": "PTDL_v1"
     },
-    "exported_at": "2020-10-19T23:26:07+00:00",
+    "exported_at": "2021-11-29T23:26:07+00:00",
     "name": "Paper",
     "author": "parker@pterodactyl.io",
     "description": "High performance Spigot fork that aims to fix gameplay and mechanics inconsistencies.",

--- a/stock_eggs/minecraft/egg-paper.json
+++ b/stock_eggs/minecraft/egg-paper.json
@@ -9,8 +9,10 @@
     "description": "High performance Spigot fork that aims to fix gameplay and mechanics inconsistencies.",
     "image": "quay.io\/pterodactyl\/core:java-11",
     "images": [
-        "quay.io\/pterodactyl\/core:java",
-        "quay.io\/pterodactyl\/core:java-11"
+        "ghcr.io\/pterodactyl\/yolks:java_8",
+        "ghcr.io\/pterodactyl\/yolks:java_11",
+        "ghcr.io\/pterodactyl\/yolks:java_16",
+        "ghcr.io\/pterodactyl\/yolks:java_17"
     ],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",
     "config": {

--- a/stock_eggs/minecraft/egg-vanilla-minecraft.json
+++ b/stock_eggs/minecraft/egg-vanilla-minecraft.json
@@ -3,14 +3,16 @@
     "meta": {
         "version": "PTDL_v1"
     },
-    "exported_at": "2020-10-23T23:04:17+00:00",
+    "exported_at": "2021-11-29T23:04:17+00:00",
     "name": "Vanilla Minecraft",
     "author": "support@pterodactyl.io",
     "description": "Minecraft is a game about placing blocks and going on adventures. Explore randomly generated worlds and build amazing things from the simplest of homes to the grandest of castles. Play in Creative Mode with unlimited resources or mine deep in Survival Mode, crafting weapons and armor to fend off dangerous mobs. Do all this alone or with friends.",
     "image": "quay.io\/pterodactyl\/core:java",
     "images": [
-        "quay.io\/pterodactyl\/core:java",
-        "quay.io\/pterodactyl\/core:java-11"
+        "ghcr.io\/pterodactyl\/yolks:java_8",
+        "ghcr.io\/pterodactyl\/yolks:java_11",
+        "ghcr.io\/pterodactyl\/yolks:java_16",
+        "ghcr.io\/pterodactyl\/yolks:java_17"
     ],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",
     "config": {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Did you branch your changes and PR from that branch and not from your master branch?


### Changes to an existing Egg:

1. [x] Have you added an explanation of what your changes do and why you'd like us to include them?

Most eggs are already update to those images why shouldn't we do the same with this two?
I would like to add this so that if someone downloads the egg from here it will automatically have the correct images.