### PR TITLE
Update Velocity Egg to support Paper API v2

### DIFF
--- a/game_eggs/minecraft/proxy/java/velocity/egg-velocity.json
+++ b/game_eggs/minecraft/proxy/java/velocity/egg-velocity.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v1",
         "update_url": null
     },
-    "exported_at": "2021-12-01T13:32:19+00:00",
+    "exported_at": "2021-12-01T13:38:50+00:00",
     "name": "Velocity",
     "author": "parker@parkervcp.com",
     "description": "Velocity is a Minecraft server proxy with unparalleled server support, scalability, and flexibility.",
@@ -50,6 +50,24 @@
             "default_value": "velocity.jar",
             "user_viewable": true,
             "user_editable": false,
+            "rules": "required|string|max:20"
+        },
+        {
+            "name": "Download Path",
+            "description": "A URL to use to download a server.jar rather than the ones in the install script. This is not user viewable.",
+            "env_variable": "DL_PATH",
+            "default_value": "",
+            "user_viewable": false,
+            "user_editable": false,
+            "rules": "nullable|string"
+        },
+        {
+            "name": "Build Number",
+            "description": "The build number for the velocity release.\r\n\r\nLeave at latest to always get the latest version. Invalid versions will default to latest.",
+            "env_variable": "BUILD_NUMBER",
+            "default_value": "latest",
+            "user_viewable": true,
+            "user_editable": true,
             "rules": "required|string|max:20"
         }
     ]

--- a/game_eggs/minecraft/proxy/java/velocity/egg-velocity.json
+++ b/game_eggs/minecraft/proxy/java/velocity/egg-velocity.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v1",
         "update_url": null
     },
-    "exported_at": "2021-07-02T04:14:48+03:00",
+    "exported_at": "2021-12-01T13:32:19+00:00",
     "name": "Velocity",
     "author": "parker@parkervcp.com",
     "description": "Velocity is a Minecraft server proxy with unparalleled server support, scalability, and flexibility.",
@@ -28,8 +28,8 @@
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/ash\r\n# Velocity Proxy Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\n\r\napk add --no-cache curl\r\n\r\nmkdir -p \/mnt\/server\/\r\n\r\ncd \/mnt\/server\/\r\n\r\nif [ -z ${VELOCITY_VERSION} ] || [ ${VELOCITY_VERSION} == \"latest\" ]; then\r\n\tVELOCITY_VERSION=\"latest\"\r\nfi\r\n\r\necho -e \"Getting download link\"\r\nDOWNLOAD_LINK=https:\/\/versions.velocitypowered.com\/download\/${VELOCITY_VERSION}\r\n\r\necho -e \"Downloading ${DOWNLOAD_LINK}\"\r\ncurl ${DOWNLOAD_LINK} -o ${SERVER_JARFILE}\r\n\r\nif [ -f velocity.toml ]; then\r\n    echo -e \"velocity config file exists\"\r\nelse\r\n    echo -e \"downloading velocity config file.\"\r\n    curl https:\/\/raw.githubusercontent.com\/parkervcp\/eggs\/master\/game_eggs\/minecraft\/proxy\/java\/velocity\/velocity.toml -o velocity.toml\r\nfi\r\n\r\necho -e \"install complete\"",
-            "container": "alpine:3.10",
+            "script": "#!\/bin\/ash\r\n# Velocity Proxy Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\nPROJECT=velocity\r\nif [ -z ${VELOCITY_VERSION} ] || [ ${VELOCITY_VERSION} == \"latest\" ]; then\r\nVELOCITY_VERSION=\"latest\"\r\nfi\r\nif [ -n \"${DOWNLOAD_LINK}\" ]; then\r\necho -e \"Using supplied download url: ${DOWNLOAD_LINK}\"\r\nDOWNLOAD_URL=`eval echo $(echo ${DL_PATH} | sed -e 's\/{{\/${\/g' -e 's\/}}\/}\/g')`\r\nelse\r\nVER_EXISTS=`curl -s https:\/\/papermc.io\/api\/v2\/projects\/${PROJECT} | jq -r --arg VERSION $VELOCITY_VERSION '.versions[] | contains($VERSION)' | grep true`\r\nLATEST_VERSION=`curl -s https:\/\/papermc.io\/api\/v2\/projects\/${PROJECT} | jq -r '.versions' | jq -r '.[-1]'`\r\nif [ \"${VER_EXISTS}\" == \"true\" ]; then\r\necho -e \"Version is valid. Using version ${VELOCITY_VERSION}\"\r\nelse\r\necho -e \"Using the latest ${PROJECT} version\"\r\nVELOCITY_VERSION=${LATEST_VERSION}\r\nfi\r\nBUILD_EXISTS=`curl -s https:\/\/papermc.io\/api\/v2\/projects\/${PROJECT}\/versions\/${VELOCITY_VERSION} | jq -r --arg BUILD ${BUILD_NUMBER} '.builds[] | tostring | contains($BUILD)' | grep true`\r\nLATEST_BUILD=`curl -s https:\/\/papermc.io\/api\/v2\/projects\/${PROJECT}\/versions\/${VELOCITY_VERSION} | jq -r '.builds' | jq -r '.[-1]'`\r\nif [ \"${BUILD_EXISTS}\" == \"true\" ]; then\r\necho -e \"Build is valid for version ${VELOCITY_VERSION}. Using build ${BUILD_NUMBER}\"\r\nelse\r\necho -e \"Using the latest ${PROJECT} build for version ${VELOCITY_VERSION}\"\r\nBUILD_NUMBER=${LATEST_BUILD}\r\nfi\r\nJAR_NAME=${PROJECT}-${VELOCITY_VERSION}-${BUILD_NUMBER}.jar\r\necho \"Version being downloaded\"\r\necho -e \"Velocity Version: ${VELOCITY_VERSION}\"\r\necho -e \"Build: ${BUILD_NUMBER}\"\r\necho -e \"JAR Name of Build: ${JAR_NAME}\"\r\nDOWNLOAD_URL=https:\/\/papermc.io\/api\/v2\/projects\/${PROJECT}\/versions\/${VELOCITY_VERSION}\/builds\/${BUILD_NUMBER}\/downloads\/${JAR_NAME}\r\nfi\r\ncd \/mnt\/server\r\necho -e \"Running curl -o ${SERVER_JARFILE} ${DOWNLOAD_URL}\"\r\nif [ -f ${SERVER_JARFILE} ]; then\r\nmv ${SERVER_JARFILE} ${SERVER_JARFILE}.old\r\nfi\r\ncurl -o ${SERVER_JARFILE} ${DOWNLOAD_URL}\r\nif [ -f velocity.toml ]; then\r\necho -e \"velocity config file exists\"\r\nelse\r\necho -e \"downloading velocity config file.\"\r\ncurl https:\/\/raw.githubusercontent.com\/parkervcp\/eggs\/master\/game_eggs\/minecraft\/proxy\/java\/velocity\/velocity.toml -o velocity.toml\r\nfi\r\necho -e \"install complete\"",
+            "container": "ghcr.io\/pterodactyl\/installers:alpine",
             "entrypoint": "ash"
         }
     },

--- a/game_eggs/minecraft/proxy/java/velocity/egg-velocity.json
+++ b/game_eggs/minecraft/proxy/java/velocity/egg-velocity.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v1",
         "update_url": null
     },
-    "exported_at": "2021-12-01T13:38:50+00:00",
+    "exported_at": "2021-12-02T16:47:41+00:00",
     "name": "Velocity",
     "author": "parker@parkervcp.com",
     "description": "Velocity is a Minecraft server proxy with unparalleled server support, scalability, and flexibility.",
@@ -13,10 +13,10 @@
         "java_version"
     ],
     "images": [
-        "ghcr.io\/pterodactyl\/yolks:java_8",
-        "ghcr.io\/pterodactyl\/yolks:java_11",
+        "ghcr.io\/pterodactyl\/yolks:java_17",
         "ghcr.io\/pterodactyl\/yolks:java_16",
-        "ghcr.io\/pterodactyl\/yolks:java_17"
+        "ghcr.io\/pterodactyl\/yolks:java_11",
+        "ghcr.io\/pterodactyl\/yolks:java_8"
     ],
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -XX:+UseG1GC -XX:G1HeapRegionSize=4M -XX:+UnlockExperimentalVMOptions -XX:+ParallelRefProcEnabled -XX:+AlwaysPreTouch -XX:MaxInlineLevel=15 -jar {{SERVER_JARFILE}}",
@@ -28,7 +28,7 @@
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/ash\r\n# Velocity Proxy Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\nPROJECT=velocity\r\nif [ -z ${VELOCITY_VERSION} ] || [ ${VELOCITY_VERSION} == \"latest\" ]; then\r\nVELOCITY_VERSION=\"latest\"\r\nfi\r\nif [ -n \"${DOWNLOAD_LINK}\" ]; then\r\necho -e \"Using supplied download url: ${DOWNLOAD_LINK}\"\r\nDOWNLOAD_URL=`eval echo $(echo ${DL_PATH} | sed -e 's\/{{\/${\/g' -e 's\/}}\/}\/g')`\r\nelse\r\nVER_EXISTS=`curl -s https:\/\/papermc.io\/api\/v2\/projects\/${PROJECT} | jq -r --arg VERSION $VELOCITY_VERSION '.versions[] | contains($VERSION)' | grep true`\r\nLATEST_VERSION=`curl -s https:\/\/papermc.io\/api\/v2\/projects\/${PROJECT} | jq -r '.versions' | jq -r '.[-1]'`\r\nif [ \"${VER_EXISTS}\" == \"true\" ]; then\r\necho -e \"Version is valid. Using version ${VELOCITY_VERSION}\"\r\nelse\r\necho -e \"Using the latest ${PROJECT} version\"\r\nVELOCITY_VERSION=${LATEST_VERSION}\r\nfi\r\nBUILD_EXISTS=`curl -s https:\/\/papermc.io\/api\/v2\/projects\/${PROJECT}\/versions\/${VELOCITY_VERSION} | jq -r --arg BUILD ${BUILD_NUMBER} '.builds[] | tostring | contains($BUILD)' | grep true`\r\nLATEST_BUILD=`curl -s https:\/\/papermc.io\/api\/v2\/projects\/${PROJECT}\/versions\/${VELOCITY_VERSION} | jq -r '.builds' | jq -r '.[-1]'`\r\nif [ \"${BUILD_EXISTS}\" == \"true\" ]; then\r\necho -e \"Build is valid for version ${VELOCITY_VERSION}. Using build ${BUILD_NUMBER}\"\r\nelse\r\necho -e \"Using the latest ${PROJECT} build for version ${VELOCITY_VERSION}\"\r\nBUILD_NUMBER=${LATEST_BUILD}\r\nfi\r\nJAR_NAME=${PROJECT}-${VELOCITY_VERSION}-${BUILD_NUMBER}.jar\r\necho \"Version being downloaded\"\r\necho -e \"Velocity Version: ${VELOCITY_VERSION}\"\r\necho -e \"Build: ${BUILD_NUMBER}\"\r\necho -e \"JAR Name of Build: ${JAR_NAME}\"\r\nDOWNLOAD_URL=https:\/\/papermc.io\/api\/v2\/projects\/${PROJECT}\/versions\/${VELOCITY_VERSION}\/builds\/${BUILD_NUMBER}\/downloads\/${JAR_NAME}\r\nfi\r\ncd \/mnt\/server\r\necho -e \"Running curl -o ${SERVER_JARFILE} ${DOWNLOAD_URL}\"\r\nif [ -f ${SERVER_JARFILE} ]; then\r\nmv ${SERVER_JARFILE} ${SERVER_JARFILE}.old\r\nfi\r\ncurl -o ${SERVER_JARFILE} ${DOWNLOAD_URL}\r\nif [ -f velocity.toml ]; then\r\necho -e \"velocity config file exists\"\r\nelse\r\necho -e \"downloading velocity config file.\"\r\ncurl https:\/\/raw.githubusercontent.com\/parkervcp\/eggs\/master\/game_eggs\/minecraft\/proxy\/java\/velocity\/velocity.toml -o velocity.toml\r\nfi\r\necho -e \"install complete\"",
+            "script": "#!\/bin\/ash\r\n# Velocity Proxy Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\nPROJECT=velocity\r\n\r\nif [[ -z ${VELOCITY_VERSION} ]] || [[ ${VELOCITY_VERSION} == \"latest\" ]]; then\r\n    VELOCITY_VERSION=\"latest\"\r\nfi\r\n\r\nif [[ -n \"${DOWNLOAD_LINK}\" ]]; then\r\n    echo -e \"Using supplied download url: ${DOWNLOAD_LINK}\"\r\n    DOWNLOAD_URL=$(eval echo $(echo ${DL_PATH} | sed -e 's\/{{\/${\/g' -e 's\/}}\/}\/g'))\r\nelse\r\n\r\n    VER_EXISTS=$(curl -s https:\/\/papermc.io\/api\/v2\/projects\/${PROJECT} | jq -r --arg VERSION $VELOCITY_VERSION '.versions[] | contains($VERSION)' | grep true)\r\n    LATEST_VERSION=$(curl -s https:\/\/papermc.io\/api\/v2\/projects\/${PROJECT} | jq -r '.versions' | jq -r '.[-1]')\r\n\r\n    if [[ \"${VER_EXISTS}\" == \"true\" ]]; then\r\n        echo -e \"Version is valid. Using version ${VELOCITY_VERSION}\"\r\n    else\r\n\r\n        echo -e \"Using the latest ${PROJECT} version\"\r\n        VELOCITY_VERSION=${LATEST_VERSION}\r\n    fi\r\n    BUILD_EXISTS=$(curl -s https:\/\/papermc.io\/api\/v2\/projects\/${PROJECT}\/versions\/${VELOCITY_VERSION} | jq -r --arg BUILD ${BUILD_NUMBER} '.builds[] | tostring | contains($BUILD)' | grep true)\r\n    LATEST_BUILD=$(curl -s https:\/\/papermc.io\/api\/v2\/projects\/${PROJECT}\/versions\/${VELOCITY_VERSION} | jq -r '.builds' | jq -r '.[-1]')\r\n\r\n    if [[ \"${BUILD_EXISTS}\" == \"true\" ]]; then\r\n        echo -e \"Build is valid for version ${VELOCITY_VERSION}. Using build ${BUILD_NUMBER}\"\r\n    else\r\n        echo -e \"Using the latest ${PROJECT} build for version ${VELOCITY_VERSION}\"\r\n        BUILD_NUMBER=${LATEST_BUILD}\r\n    fi\r\n\r\n    JAR_NAME=${PROJECT}-${VELOCITY_VERSION}-${BUILD_NUMBER}.jar\r\n\r\n    echo \"Version being downloaded\"\r\n    echo -e \"Velocity Version: ${VELOCITY_VERSION}\"\r\n    echo -e \"Build: ${BUILD_NUMBER}\"\r\n    echo -e \"JAR Name of Build: ${JAR_NAME}\"\r\n\r\n    DOWNLOAD_URL=https:\/\/papermc.io\/api\/v2\/projects\/${PROJECT}\/versions\/${VELOCITY_VERSION}\/builds\/${BUILD_NUMBER}\/downloads\/${JAR_NAME}\r\nfi\r\n\r\ncd \/mnt\/server\r\necho -e \"Running curl -o ${SERVER_JARFILE} ${DOWNLOAD_URL}\"\r\n\r\nif [[ -f ${SERVER_JARFILE} ]]; then\r\n    mv ${SERVER_JARFILE} ${SERVER_JARFILE}.old\r\nfi\r\n\r\ncurl -o ${SERVER_JARFILE} ${DOWNLOAD_URL}\r\nif [[ -f velocity.toml ]]; then\r\n    echo -e \"velocity config file exists\"\r\nelse\r\n    echo -e \"downloading velocity config file.\"\r\n    curl https:\/\/raw.githubusercontent.com\/parkervcp\/eggs\/master\/game_eggs\/minecraft\/proxy\/java\/velocity\/velocity.toml -o velocity.toml\r\n\r\nfi\r\necho -e \"install complete\"",
             "container": "ghcr.io\/pterodactyl\/installers:alpine",
             "entrypoint": "ash"
         }


### PR DESCRIPTION
Velocity has been acquired by PaperMC. I have used the PaperMC download script in the velocity egg and modified it a little

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to an existing Egg:

1. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [x] Have you tested your Egg changes?
