### PR TITLE
Fix Cloudburst Nukkit download links

### DIFF
--- a/game_eggs/minecraft/bedrock/nukkit/egg-nukkit.json
+++ b/game_eggs/minecraft/bedrock/nukkit/egg-nukkit.json
@@ -4,25 +4,29 @@
         "version": "PTDL_v1",
         "update_url": null
     },
-    "exported_at": "2021-07-02T03:55:04+03:00",
+    "exported_at": "2021-12-15T12:51:36-05:00",
     "name": "Nukkit",
     "author": "parker@parkervcp.com",
-    "description": "Nukkit is a Nuclear-Powered Server Software For Minecraft: Pocket Edition\r\n\r\nhttps:\/\/nukkit.io\/",
+    "description": "Nukkit is a Nuclear-Powered Server Software For Minecraft: Pocket Edition\r\n\r\nhttps:\/\/cloudburst.org\/",
     "features": null,
     "images": [
-        "quay.io\/pterodactyl\/core:java-glibc"
+        "quay.io\/pterodactyl\/core:java-glibc",
+        "ghcr.io\/pterodactyl\/yolks:java_11",
+        "ghcr.io\/pterodactyl\/yolks:java_16",
+        "ghcr.io\/pterodactyl\/yolks:java_8",
+        "ghcr.io\/pterodactyl\/yolks:java_17"
     ],
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",
     "config": {
         "files": "{\r\n    \"server.properties\": {\r\n        \"parser\": \"properties\",\r\n        \"find\": {\r\n            \"server-ip\": \"0.0.0.0\",\r\n            \"enable-query\": \"true\",\r\n            \"server-port\": \"{{server.build.default.port}}\",\r\n            \"query.port\": \"{{server.build.default.port}}\"\r\n        }\r\n    }\r\n}",
-        "startup": "{\r\n    \"done\": \")! For help, type \",\r\n    \"userInteraction\": [\r\n        \"Go to eula.txt for more info.\"\r\n    ]\r\n}",
+        "startup": "{\r\n    \"done\": \")! For help, type \"\r\n}",
         "logs": "{\r\n    \"custom\": false,\r\n    \"location\": \"logs\/latest.log\"\r\n}",
         "stop": "stop"
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/ash\r\n# Nukkit Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\napk add --no-cache curl openssl\r\n\r\ncd \/mnt\/server\r\n\r\n## Only download if a path is provided, otherwise continue.\r\nif [ ! -z \"${DL_PATH}\" ]; then\r\n    MODIFIED_DOWNLOAD=`eval echo $(echo ${DL_PATH} | sed -e 's\/{{\/${\/g' -e 's\/}}\/}\/g')`\r\n    wget ${MODIFIED_DOWNLOAD} -O ${SERVER_JARFILE}\r\nelif [ -z \"${NUKKIT_VERSION}\" ] || [ \"${NUKKIT_VERSION}\" == \"latest\" ]; then\r\n    wget https:\/\/ci.opencollab.dev\/job\/NukkitX\/job\/Nukkit\/job\/master\/lastSuccessfulBuild\/artifact\/target\/nukkit-1.0-SNAPSHOT.jar -O ${SERVER_JARFILE}\r\nelse\r\n    wget https:\/\/ci.opencollab.dev\/job\/NukkitX\/job\/Nukkit\/job\/master\/${NUKKIT_VERSION}\/artifact\/target\/nukkit-1.0-SNAPSHOT.jar -O ${SERVER_JARFILE}\r\nfi\r\n\r\nif [ ! -f nukkit.yml ]; then\r\n    wget https:\/\/raw.githubusercontent.com\/parkervcp\/eggs\/master\/game_eggs\/minecraft\/bedrock\/nukkit\/nukkit.yml\r\nfi\r\n\r\nif [ ! -f server.properties ]; then\r\n    wget https:\/\/raw.githubusercontent.com\/parkervcp\/eggs\/master\/game_eggs\/minecraft\/bedrock\/nukkit\/server.properties\r\nfi",
+            "script": "#!\/bin\/ash\r\n# Nukkit Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\napk add --no-cache curl openssl\r\n\r\ncd \/mnt\/server\r\n\r\n## Only download if a path is provided, otherwise continue.\r\nif [ ! -z \"${DL_PATH}\" ]; then\r\n    MODIFIED_DOWNLOAD=`eval echo $(echo ${DL_PATH} | sed -e 's\/{{\/${\/g' -e 's\/}}\/}\/g')`\r\n    wget ${MODIFIED_DOWNLOAD} -O ${SERVER_JARFILE}\r\nelif [ -z \"${NUKKIT_VERSION}\" ] || [ \"${NUKKIT_VERSION}\" == \"latest\" ]; then\r\n    wget https:\/\/repo.opencollab.dev\/artifactory\/maven-snapshots\/cn\/nukkit\/nukkit\/1.0-SNAPSHOT\/nukkit-1.0-SNAPSHOT.jar -O ${SERVER_JARFILE}\r\nelse\r\n    wget https:\/\/ci.opencollab.dev\/job\/NukkitX\/job\/Nukkit\/job\/master\/${NUKKIT_VERSION}\/artifact\/target\/nukkit-1.0-SNAPSHOT.jar -O ${SERVER_JARFILE}\r\nfi\r\n\r\nif [ ! -f nukkit.yml ]; then\r\n    wget https:\/\/raw.githubusercontent.com\/parkervcp\/eggs\/master\/game_eggs\/minecraft\/bedrock\/nukkit\/nukkit.yml\r\nfi\r\n\r\nif [ ! -f server.properties ]; then\r\n    wget https:\/\/raw.githubusercontent.com\/parkervcp\/eggs\/master\/game_eggs\/minecraft\/bedrock\/nukkit\/server.properties\r\nfi\r\necho -e \"Install completed!\"",
             "container": "alpine:3.10",
             "entrypoint": "ash"
         }

--- a/game_eggs/minecraft/bedrock/nukkit/egg-nukkit.json
+++ b/game_eggs/minecraft/bedrock/nukkit/egg-nukkit.json
@@ -4,10 +4,10 @@
         "version": "PTDL_v1",
         "update_url": null
     },
-    "exported_at": "2021-12-15T12:51:36-05:00",
+    "exported_at": "2021-12-16T13:31:45-05:00",
     "name": "Nukkit",
     "author": "parker@parkervcp.com",
-    "description": "Nukkit is a Nuclear-Powered Server Software For Minecraft: Pocket Edition\r\n\r\nhttps:\/\/cloudburst.org\/",
+    "description": "Nukkit is a Nuclear-Powered Server Software For Minecraft: Pocket Edition\r\n\r\nhttps:\/\/cloudburstmc.org",
     "features": null,
     "images": [
         "quay.io\/pterodactyl\/core:java-glibc",
@@ -26,7 +26,7 @@
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/ash\r\n# Nukkit Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\napk add --no-cache curl openssl\r\n\r\ncd \/mnt\/server\r\n\r\n## Only download if a path is provided, otherwise continue.\r\nif [ ! -z \"${DL_PATH}\" ]; then\r\n    MODIFIED_DOWNLOAD=`eval echo $(echo ${DL_PATH} | sed -e 's\/{{\/${\/g' -e 's\/}}\/}\/g')`\r\n    wget ${MODIFIED_DOWNLOAD} -O ${SERVER_JARFILE}\r\nelif [ -z \"${NUKKIT_VERSION}\" ] || [ \"${NUKKIT_VERSION}\" == \"latest\" ]; then\r\n    wget https:\/\/repo.opencollab.dev\/artifactory\/maven-snapshots\/cn\/nukkit\/nukkit\/1.0-SNAPSHOT\/nukkit-1.0-SNAPSHOT.jar -O ${SERVER_JARFILE}\r\nelse\r\n    wget https:\/\/ci.opencollab.dev\/job\/NukkitX\/job\/Nukkit\/job\/master\/${NUKKIT_VERSION}\/artifact\/target\/nukkit-1.0-SNAPSHOT.jar -O ${SERVER_JARFILE}\r\nfi\r\n\r\nif [ ! -f nukkit.yml ]; then\r\n    wget https:\/\/raw.githubusercontent.com\/parkervcp\/eggs\/master\/game_eggs\/minecraft\/bedrock\/nukkit\/nukkit.yml\r\nfi\r\n\r\nif [ ! -f server.properties ]; then\r\n    wget https:\/\/raw.githubusercontent.com\/parkervcp\/eggs\/master\/game_eggs\/minecraft\/bedrock\/nukkit\/server.properties\r\nfi\r\necho -e \"Install completed!\"",
+            "script": "#!\/bin\/ash\r\n# Nukkit Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\napk add --no-cache curl openssl\r\n\r\ncd \/mnt\/server\r\n\r\n## Only download if a path is provided, otherwise continue.\r\nif [ ! -z \"${DL_PATH}\" ]; then\r\n    MODIFIED_DOWNLOAD=`eval echo $(echo ${DL_PATH} | sed -e 's\/{{\/${\/g' -e 's\/}}\/}\/g')`\r\n    wget ${MODIFIED_DOWNLOAD} -O ${SERVER_JARFILE}\r\nelif [ -z \"${NUKKIT_VERSION}\" ] || [ \"${NUKKIT_VERSION}\" == \"latest\" ]; then\r\n    wget https:\/\/ci.opencollab.dev\/job\/NukkitX\/job\/Nukkit\/job\/master\/lastSuccessfulBuild\/artifact\/target\/nukkit-1.0-SNAPSHOT.jar -O ${SERVER_JARFILE}\r\nelse\r\n    wget https:\/\/ci.opencollab.dev\/job\/NukkitX\/job\/Nukkit\/job\/master\/${NUKKIT_VERSION}\/artifact\/target\/nukkit-1.0-SNAPSHOT.jar -O ${SERVER_JARFILE}\r\nfi\r\n\r\nif [ ! -f nukkit.yml ]; then\r\n    wget https:\/\/raw.githubusercontent.com\/parkervcp\/eggs\/master\/game_eggs\/minecraft\/bedrock\/nukkit\/nukkit.yml\r\nfi\r\n\r\nif [ ! -f server.properties ]; then\r\n    wget https:\/\/raw.githubusercontent.com\/parkervcp\/eggs\/master\/game_eggs\/minecraft\/bedrock\/nukkit\/server.properties\r\nfi\r\n\r\necho -s \"Install completed!\"",
             "container": "alpine:3.10",
             "entrypoint": "ash"
         }
@@ -43,7 +43,7 @@
         },
         {
             "name": "Download Path",
-            "description": "A URL to use to download Spigot rather than building it on the server. This is not user viewable. Use <code>{{DL_VERSION}}<\/code> in the URL to automatically insert the assigned version into the URL. If you do not enter a URL Spigot will build directly in the container (this will fail on low memory containers).",
+            "description": "A URL to use to download Nukkit rather than building it on the server. This is not user viewable. Use <code>{{DL_VERSION}}<\/code> in the URL to automatically insert the assigned version into the URL. If you do not enter a URL Spigot will build directly in the container (this will fail on low memory containers).",
             "env_variable": "DL_PATH",
             "default_value": "",
             "user_viewable": false,


### PR DESCRIPTION
### All Submissions:

* [x ] Have you followed the guidelines in our Contributing document?
* [x ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [ ] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:
Just a quick fix, no new files.

1. [x ] Have you added an explanation of what your changes do and why you'd like us to include them? 
its below
2. [x ] Have you tested your Egg changes?

The download URL for the nukkit CI seems to have changed, so I updated that and a few other links that were dead.
With the new links it seems older versions cant be downloaded, so I left them as-is
Also, there is no eula promt for nukkit, so thats yeeted.