### PR TITLE
Update Startup Done Tag to New Behavior

### DIFF
--- a/game_eggs/steamcmd_servers/risk_of_rain_2/egg-risk-of-rain2.json
+++ b/game_eggs/steamcmd_servers/risk_of_rain_2/egg-risk-of-rain2.json
@@ -16,7 +16,7 @@
     "startup": "xvfb-run wine .\/\"Risk of Rain 2.exe\"",
     "config": {
         "files": "{\r\n    \".\/Risk of Rain 2_Data\/Config\/server.cfg\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"sv_password\": \"sv_password \\\"{{server.build.env.PASSWORD}}\\\";\",\r\n            \"steam_server_heartbeat_enabled\": \"steam_server_heartbeat_enabled {{server.build.env.ADVERTISE}};\",\r\n            \"sv_hostname\": \"sv_hostname \\\"{{server.build.env.HOSTNAME}}\\\";\",\r\n            \"steam_server_query_port\": \"steam_server_query_port {{server.build.env.QUERY}};\",\r\n            \"steam_server_steam_port\": \"steam_server_steam_port {{server.build.env.STEAM}};\",\r\n            \"sv_maxplayers\": \"sv_maxplayers {{server.build.env.PLAYERS}};\",\r\n            \"exec server;\": \"\",\r\n            \"host\": \"\",\r\n            \"remove_all_local_users;\": \"\"\r\n        }\r\n    }\r\n}",
-        "startup": "{\r\n    \"done\": \"Press Enter to chat.\"\r\n}",
+        "startup": "{\r\n    \"done\": \"CHAT_KEYBIND_TIP\"\r\n}",
         "logs": "{}",
         "stop": "^V"
     },


### PR DESCRIPTION
This change fixes the Risk of Rain 2 server remaining in the STARTING state forever. Due to a recent change in the game server, the game no longer properly executes the substitutions for translations, so the game will only print the untranslated internal string name `CHAT_KEYBIND_TIP`.

I tested these changes within my fresh Pterodactyl installation under a fresh instance to ensure it worked properly.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?: N/A

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to an existing Egg:

1. [X] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [X] Have you tested your Egg changes?
