### PR TITLE
Fix mohist download url & make jar file viewable

### DIFF
--- a/game_eggs/minecraft/java/mohist/egg-mohist.json
+++ b/game_eggs/minecraft/java/mohist/egg-mohist.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v1",
         "update_url": null
     },
-    "exported_at": "2021-06-14T21:28:24+03:00",
+    "exported_at": "2022-01-14T09:54:36+01:00",
     "name": "Mohist",
     "author": "alex.chang-lam@protonmail.com",
     "description": "Spigot fork with performance optimizations.",
@@ -28,7 +28,7 @@
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/bash\r\n# Mohist Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\napt update\r\napt install -y curl\r\n\r\n#Go into main direction\r\nif [ ! -d \/mnt\/server ]; then\r\n    mkdir \/mnt\/server\r\nfi\r\n\r\ncd \/mnt\/server\r\n\r\nif [ ! -z ${BUILD_VERSION} ]; then\r\n    DOWNLOAD_LINK=https:\/\/mohistmc.com\/api\/${MC_VERSION}\/${BUILD_VERSION}\/download\r\nelse\r\n    DOWNLOAD_LINK=https:\/\/mohistmc.com\/api\/${MC_VERSION}\/${BUILD_TYPE}\/download\r\nfi\r\n\r\n#Downloading jars\r\necho -e \"Download link is ${DOWNLOAD_LINK}\"\r\necho -e \"Downloading build version ${BUILD_VERSION}\"\r\nif [ ! -z \"${DOWNLOAD_LINK}\" ]; then \r\n    if curl --output \/dev\/null --silent --head --fail ${DOWNLOAD_LINK}-server.jar; then\r\n        echo -e \"Download link is valid.\"\r\n    else\r\n        echo -e \"Link is invalid closing out\"\r\n        exit 2\r\n    fi\r\nfi\r\n\r\ncurl -s -o server.jar -sS ${DOWNLOAD_LINK}\r\n\r\n#Checking if downloaded jars exist\r\nif [ ! -f .\/server.jar ]; then\r\n    echo \"!!! Error downloading build version ${BUILD_VERSION} !!!\"\r\n    exit\r\nfi",
+            "script": "#!\/bin\/bash\r\n# Mohist Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\napt update\r\napt install -y curl\r\n\r\n#Go into main direction\r\nif [ ! -d \/mnt\/server ]; then\r\n    mkdir \/mnt\/server\r\nfi\r\n\r\ncd \/mnt\/server\r\n\r\nif [ ! -z ${BUILD_VERSION} ]; then\r\n    DOWNLOAD_LINK=https:\/\/mohistmc.com\/api\/${MC_VERSION}\/${BUILD_VERSION}\/download\r\nelse\r\n    DOWNLOAD_LINK=https:\/\/mohistmc.com\/api\/${MC_VERSION}\/${BUILD_TYPE}\/download\r\nfi\r\n\r\n#Downloading jars\r\necho -e \"Download link is ${DOWNLOAD_LINK}\"\r\necho -e \"Downloading build version ${BUILD_VERSION}\"\r\nif [ ! -z \"${DOWNLOAD_LINK}\" ]; then \r\n    if curl --output \/dev\/null --silent --fail ${DOWNLOAD_LINK}; then\r\n        echo -e \"Download link is valid.\"\r\n    else\r\n        echo -e \"Link is invalid closing out\"\r\n        exit 2\r\n    fi\r\nfi\r\n\r\ncurl -s -o server.jar -sS ${DOWNLOAD_LINK}\r\n\r\n#Checking if downloaded jars exist\r\nif [ ! -f .\/server.jar ]; then\r\n    echo \"!!! Error downloading build version ${BUILD_VERSION} !!!\"\r\n    exit\r\nfi",
             "container": "debian:buster-slim",
             "entrypoint": "bash"
         }
@@ -39,7 +39,7 @@
             "description": "The name of the jarfile to run the server with.",
             "env_variable": "SERVER_JARFILE",
             "default_value": "server.jar",
-            "user_viewable": false,
+            "user_viewable": true,
             "user_editable": false,
             "rules": "required|string|max:20"
         },


### PR DESCRIPTION
This fixes the download url of the mohist egg and makes the server jarfile variable user viewable so it doesn't show `-jar [hidden]` in the startup command of the Startup tab.

Install script diff: https://www.diffchecker.com/9VtS9zWK

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

### Changes to an existing Egg:

1. [X] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [X] Have you tested your Egg changes?
