### PR TITLE
feat: add pid_limit egg feature to MC eggs

### DIFF
--- a/game_eggs/minecraft/bedrock/bedrock/egg-vanilla-bedrock.json
+++ b/game_eggs/minecraft/bedrock/bedrock/egg-vanilla-bedrock.json
@@ -8,7 +8,9 @@
     "name": "Vanilla Bedrock",
     "author": "parker@parkervcp.com",
     "description": "Bedrock Edition (also known as the Bedrock Version, Bedrock Codebase, Bedrock Engine or just Bedrock) refers to the multi-platform family of editions of Minecraft developed by Mojang AB, Microsoft Studios, 4J Studios, and SkyBox Labs. Prior to this term, as the engine originated with Pocket Edition, this entire product family was referred to as \"Pocket Edition\", \"MCPE\", or \"Pocket\/Windows 10 Edition\".",
-    "features": null,
+    "features": [
+        "pid_limit"
+    ],
     "images": [
         "quay.io\/parkervcp\/pterodactyl-images:base_debian"
     ],

--- a/game_eggs/minecraft/java/airplane/egg-airplane.json
+++ b/game_eggs/minecraft/java/airplane/egg-airplane.json
@@ -10,7 +10,8 @@
     "description": "A stable, optimized and fast Paper fork.\r\nhttps:\/\/github.com\/TECHNOVE\/Airplane",
     "features": [
         "eula",
-        "java_version"
+        "java_version",
+        "pid_limit"
     ],
     "images": [
         "ghcr.io\/pterodactyl\/yolks:java_17",

--- a/game_eggs/minecraft/java/fabric/egg-fabric.json
+++ b/game_eggs/minecraft/java/fabric/egg-fabric.json
@@ -10,7 +10,8 @@
     "description": "Fabric is a modular modding toolchain targeting Minecraft 1.14 and above, including snapshots.",
     "features": [
         "eula",
-        "java_version"
+        "java_version",
+        "pid_limit"
     ],
     "images": [
         "ghcr.io\/pterodactyl\/yolks:java_17",

--- a/game_eggs/minecraft/java/forge/curseforge-generic/egg-curseforge-generic.json
+++ b/game_eggs/minecraft/java/forge/curseforge-generic/egg-curseforge-generic.json
@@ -10,7 +10,8 @@
     "description": "A generic egg for a forge modpack",
     "features": [
         "eula",
-        "java_version"
+        "java_version",
+        "pid_limit"
     ],
     "images": [
         "ghcr.io\/pterodactyl\/yolks:java_8",

--- a/game_eggs/minecraft/java/forge/forge/egg-forge-enhanced.json
+++ b/game_eggs/minecraft/java/forge/forge/egg-forge-enhanced.json
@@ -10,7 +10,8 @@
     "description": "Minecraft Forge Server. Minecraft Forge is a modding API (Application Programming Interface), which makes it easier to create mods, and also make sure mods are compatible with each other.",
     "features": [
         "eula",
-        "java_version"
+        "java_version",
+        "pid_limit"
     ],
     "images": [
         "ghcr.io\/pterodactyl\/yolks:java_17",

--- a/game_eggs/minecraft/java/ftb/egg-ftb-modpacksch-server.json
+++ b/game_eggs/minecraft/java/ftb/egg-ftb-modpacksch-server.json
@@ -10,7 +10,8 @@
     "description": "Since the release of the FTB APP, FTB modpacks are now distributed through modpacks.ch. This egg was developed for support for modpacks that are distributed through this.",
     "features": [
         "eula",
-        "java_version"
+        "java_version",
+        "pid_limit"
     ],
     "images": [
         "ghcr.io\/pterodactyl\/yolks:java_8",

--- a/game_eggs/minecraft/java/krypton/egg-krypton.json
+++ b/game_eggs/minecraft/java/krypton/egg-krypton.json
@@ -10,7 +10,8 @@
   "description": "A fast, lightweight Minecraft server written in Kotlin",
   "features": [
     "eula",
-    "java_version"
+    "java_version",
+    "pid_limit"
 ],
   "images": [
     "ghcr.io\/pterodactyl\/yolks:java_8",

--- a/game_eggs/minecraft/java/magma/egg-magma.json
+++ b/game_eggs/minecraft/java/magma/egg-magma.json
@@ -10,7 +10,8 @@
     "description": "Magma is most powerful Forge server providing you with Forge mods and Bukkit Plugins using Spigot and Paper for Performance Optimization and Stability.",
     "features": [
         "eula",
-        "java_version"
+        "java_version",
+        "pid_limit"
     ],
     "images": [
         "ghcr.io\/pterodactyl\/yolks:java_8",

--- a/game_eggs/minecraft/java/mohist/egg-mohist.json
+++ b/game_eggs/minecraft/java/mohist/egg-mohist.json
@@ -10,7 +10,8 @@
     "description": "Spigot fork with performance optimizations.",
     "features": [
         "eula",
-        "java_version"
+        "java_version",
+        "pid_limit"
     ],
     "images": [
         "ghcr.io\/pterodactyl\/yolks:java_8",

--- a/game_eggs/minecraft/java/nanolimbo/egg-nano-limbo.json
+++ b/game_eggs/minecraft/java/nanolimbo/egg-nano-limbo.json
@@ -8,7 +8,11 @@
     "name": "NanoLimbo",
     "author": "mail@wuffy.eu",
     "description": "This is lightweight minecraft limbo server, written on Java with Netty. The main goal of the project is maximum simplicity with a minimum number of sent and processed packets. This limbo is empty, there are no ability to set schematic building since this is not necessary. You can send useful information in chat or BossBar.\r\n\r\nNo plugins, no logs. The server is fully clear. It only able keep a lot of players while the main server is down.",
-    "features": null,
+    "features": [
+        "eula",
+        "java_version",
+        "pid_limit"
+    ],
     "images": [
         "ghcr.io\/pterodactyl\/yolks:java_8"
     ],

--- a/game_eggs/minecraft/java/paper/egg-paper.json
+++ b/game_eggs/minecraft/java/paper/egg-paper.json
@@ -10,7 +10,8 @@
     "description": "High performance Spigot fork that aims to fix gameplay and mechanics inconsistencies.",
     "features": [
         "eula",
-        "java_version"
+        "java_version",
+        "pid_limit"
     ],
     "images": [
         "ghcr.io\/pterodactyl\/yolks:java_17",

--- a/game_eggs/minecraft/java/purpur/egg-purpur.json
+++ b/game_eggs/minecraft/java/purpur/egg-purpur.json
@@ -10,7 +10,8 @@
     "description": "A drop-in replacement for Paper servers designed for configurability, and new fun and exciting gameplay features.",
     "features": [
         "eula",
-        "java_version"
+        "java_version",
+        "pid_limit"
     ],
     "images": [
         "ghcr.io\/pterodactyl\/yolks:java_17",

--- a/game_eggs/minecraft/java/spigot/egg-spigot.json
+++ b/game_eggs/minecraft/java/spigot/egg-spigot.json
@@ -10,7 +10,8 @@
     "description": "Spigot is the most widely-used modded Minecraft server software in the world. It powers many of the top Minecraft server networks around to ensure they can cope with their huge player base and ensure the satisfaction of their players. Spigot works by reducing and eliminating many causes of lag, as well as adding in handy features and settings that help make your job of server administration easier.",
     "features": [
         "eula",
-        "java_version"
+        "java_version",
+        "pid_limit"
     ],
     "images": [
         "ghcr.io\/pterodactyl\/yolks:java_17",

--- a/game_eggs/minecraft/java/spongeforge/egg-sponge-forge.json
+++ b/game_eggs/minecraft/java/spongeforge/egg-sponge-forge.json
@@ -10,7 +10,8 @@
     "description": "A community-driven open source Minecraft: Java Edition modding platform.",
     "features": [
         "eula",
-        "java_version"
+        "java_version",
+        "pid_limit"
     ],
     "images": [
         "ghcr.io\/pterodactyl\/yolks:java_8",

--- a/game_eggs/minecraft/java/spongevanilla/egg-sponge-vanilla.json
+++ b/game_eggs/minecraft/java/spongevanilla/egg-sponge-vanilla.json
@@ -10,7 +10,8 @@
     "description": "SpongeVanilla is the implementation of the Sponge API on top of Vanilla Minecraft.",
     "features": [
         "eula",
-        "java_version"
+        "java_version",
+        "pid_limit"
     ],
     "images": [
         "ghcr.io\/pterodactyl\/yolks:java_17",

--- a/game_eggs/minecraft/java/tuinity/egg-tuinity.json
+++ b/game_eggs/minecraft/java/tuinity/egg-tuinity.json
@@ -10,7 +10,8 @@
     "description": "Fork of Paper aimed at improving server performance at high playercounts.",
     "features": [
         "eula",
-        "java_version"
+        "java_version",
+        "pid_limit"
     ],
     "images": [
         "ghcr.io\/pterodactyl\/yolks:java_17",

--- a/game_eggs/minecraft/java/vanillacord/egg-vanilla-cord.json
+++ b/game_eggs/minecraft/java/vanillacord/egg-vanilla-cord.json
@@ -10,7 +10,8 @@
     "description": "Minecraft is a game about placing blocks and going on adventures. Explore randomly generated worlds and build amazing things from the simplest of homes to the grandest of castles. Play in Creative Mode with unlimited resources or mine deep in Survival Mode, crafting weapons and armor to fend off dangerous mobs. Do all this alone or with friends.\r\n\r\nVanillaCord adds support for BungeeCord's ip_forward setting.",
     "features": [
         "eula",
-        "java_version"
+        "java_version",
+        "pid_limit"
     ],
     "images": [
         "ghcr.io\/pterodactyl\/yolks:java_17",

--- a/game_eggs/minecraft/proxy/bedrock/waterdog_pe/egg-waterdog-p-e.json
+++ b/game_eggs/minecraft/proxy/bedrock/waterdog_pe/egg-waterdog-p-e.json
@@ -10,7 +10,8 @@
     "description": "Brand new proxy server for Minecraft: Bedrock Edition",
     "features": [
         "eula",
-        "java_version"
+        "java_version",
+        "pid_limit"
     ],
     "images": [
         "ghcr.io\/pterodactyl\/yolks:java_17",

--- a/game_eggs/minecraft/proxy/cross_platform/waterdog/egg-waterdog.json
+++ b/game_eggs/minecraft/proxy/cross_platform/waterdog/egg-waterdog.json
@@ -10,7 +10,8 @@
     "description": "Waterdog is fork of the well-known Waterfall, which is a fork of the well-known BungeeCord, server teleportation suite.",
     "features": [
         "eula",
-        "java_version"
+        "java_version",
+        "pid_limit"
     ],
     "images": [
         "ghcr.io\/pterodactyl\/yolks:java_17",

--- a/game_eggs/minecraft/proxy/java/flamecord/egg-flamecord.json
+++ b/game_eggs/minecraft/proxy/java/flamecord/egg-flamecord.json
@@ -10,7 +10,8 @@
     "description": "FlameCord is a patch for Travertine to fix possible exploits and add useful functionalities. FlameCord aims to fix Netty related exploits to keep your server safe from attacks.",
     "features": [
         "eula",
-        "java_version"
+        "java_version",
+        "pid_limit"
     ],
     "images": [
         "ghcr.io\/pterodactyl\/yolks:java_17",

--- a/game_eggs/minecraft/proxy/java/travertine/egg-travertine.json
+++ b/game_eggs/minecraft/proxy/java/travertine/egg-travertine.json
@@ -10,7 +10,8 @@
     "description": "Travertine is a fork of Waterfall with 1.7 protocol support. Waterfall is a fork of the well-known BungeeCord server teleportation suite.",
     "features": [
         "eula",
-        "java_version"
+        "java_version",
+        "pid_limit"
     ],
     "images": [
         "ghcr.io\/pterodactyl\/yolks:java_17",

--- a/game_eggs/minecraft/proxy/java/typhoonlimbo/egg-typhoon-limbo.json
+++ b/game_eggs/minecraft/proxy/java/typhoonlimbo/egg-typhoon-limbo.json
@@ -8,7 +8,9 @@
     "name": "TyphoonLimbo",
     "author": "parker@parkervcp.com",
     "description": "Lightweight minecraft limbo server",
-    "features": null,
+    "features": [
+        "pid_limit"
+    ],
     "images": [
         "ghcr.io\/parkervcp\/yolks:debian"
     ],

--- a/game_eggs/minecraft/proxy/java/velocity/egg-velocity.json
+++ b/game_eggs/minecraft/proxy/java/velocity/egg-velocity.json
@@ -10,7 +10,8 @@
     "description": "Velocity is a Minecraft server proxy with unparalleled server support, scalability, and flexibility.",
     "features": [
         "eula",
-        "java_version"
+        "java_version",
+        "pid_limit"
     ],
     "images": [
         "ghcr.io\/pterodactyl\/yolks:java_17",

--- a/game_eggs/minecraft/proxy/java/viaaas/egg-v-i-aaa-s.json
+++ b/game_eggs/minecraft/proxy/java/viaaas/egg-v-i-aaa-s.json
@@ -10,7 +10,8 @@
     "description": "VIAaaS - ViaVersion as a Service - Standalone ViaVersion proxy",
     "features": [
         "eula",
-        "java_version"
+        "java_version",
+        "pid_limit"
     ],
     "images": [
         "ghcr.io\/pterodactyl\/yolks:java_17",

--- a/game_eggs/minecraft/proxy/java/waterfall/egg-waterfall.json
+++ b/game_eggs/minecraft/proxy/java/waterfall/egg-waterfall.json
@@ -10,7 +10,8 @@
     "description": "Waterfall is a fork of the well-known BungeeCord server teleportation suite.",
     "features": [
         "eula",
-        "java_version"
+        "java_version",
+        "pid_limit"
     ],
     "images": [
         "ghcr.io\/pterodactyl\/yolks:java_17",


### PR DESCRIPTION
A new egg feature modal was introduced in Panel v1.7.0 triggering when the pid or memory limit is reached to provide more user-friendly instructions to both admins and normal users. Other eggs might benefit from this as well, but for now, will stick with MC that are known to spawn a lot of processes when modded.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

### Changes to an existing Egg:

1. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [x] Have you tested your Egg changes?
