### PR TITLE
feat: add steam_disk_space egg feature to SteamCMD eggs

### DIFF
--- a/game_eggs/steamcmd_servers/7_days_to_die/egg-7-days-to-die.json
+++ b/game_eggs/steamcmd_servers/7_days_to_die/egg-7-days-to-die.json
@@ -8,7 +8,9 @@
     "name": "7 Days To Die",
     "author": "kristoffer.norman@bahnhof.se",
     "description": "7 days to die server",
-    "features": null,
+    "features": [
+        "steam_disk_space"
+    ],
     "images": [
         "ghcr.io\/parkervcp\/games:source"
     ],

--- a/game_eggs/steamcmd_servers/ark_survival_evolved/egg-ark--survival-evolved.json
+++ b/game_eggs/steamcmd_servers/ark_survival_evolved/egg-ark--survival-evolved.json
@@ -8,7 +8,9 @@
     "name": "Ark: Survival Evolved",
     "author": "dev@shepper.fr",
     "description": "As a man or woman stranded, naked, freezing, and starving on the unforgiving shores of a mysterious island called ARK, use your skill and cunning to kill or tame and ride the plethora of leviathan dinosaurs and other primeval creatures roaming the land. Hunt, harvest resources, craft items, grow crops, research technologies, and build shelters to withstand the elements and store valuables, all while teaming up with (or preying upon) hundreds of other players to survive, dominate... and escape! \u2014 Gamepedia: ARK",
-    "features": null,
+    "features": [
+        "steam_disk_space"
+    ],
     "images": [
         "ghcr.io\/parkervcp\/games:source"
     ],

--- a/game_eggs/steamcmd_servers/arma/arma3/egg-arma3.json
+++ b/game_eggs/steamcmd_servers/arma/arma3/egg-arma3.json
@@ -8,7 +8,9 @@
     "name": "Arma 3",
     "author": "rehlmgaming@gmail.com",
     "description": "Experience true combat gameplay in a massive military sandbox. Deploying a wide variety of single- and multiplayer content, over 20 vehicles and 40 weapons, and limitless opportunities for content creation, this is the PC's premier military game. Authentic, diverse, open - Arma 3 sends you to war.",
-    "features": null,
+    "features": [
+        "steam_disk_space"
+    ],
     "images": [
         "ghcr.io\/parkervcp\/games:arma3"
     ],

--- a/game_eggs/steamcmd_servers/assetto_corsa/egg-assetto-corsa.json
+++ b/game_eggs/steamcmd_servers/assetto_corsa/egg-assetto-corsa.json
@@ -8,7 +8,9 @@
     "name": "Assetto Corsa",
     "author": "admin@softwarenoob.com",
     "description": "Assetto Corsa (Italian for \"Race Setup\") is a sim racing video game developed by the Italian video game developer Kunos Simulazioni. It is designed with an emphasis on a realistic racing experience with support for extensive customization and moddability",
-    "features": null,
+    "features": [
+        "steam_disk_space"
+    ],
     "images": [
         "ghcr.io\/parkervcp\/games:source"
     ],

--- a/game_eggs/steamcmd_servers/avorion/egg-avorion.json
+++ b/game_eggs/steamcmd_servers/avorion/egg-avorion.json
@@ -8,7 +8,9 @@
     "name": "Avorion",
     "author": "iamkubi@gmail.com",
     "description": "A procedural co-op space sandbox where players can build their own space ships out of dynamically scalable blocks. Fight epic space battles, explore, mine, trade, wage wars and build your own empire to save your galaxy from being torn apart by an unknown enemy.",
-    "features": null,
+    "features": [
+        "steam_disk_space"
+    ],
     "images": [
         "ghcr.io\/parkervcp\/games:source"
     ],

--- a/game_eggs/steamcmd_servers/barotrauma/egg-barotrauma.json
+++ b/game_eggs/steamcmd_servers/barotrauma/egg-barotrauma.json
@@ -8,7 +8,9 @@
     "name": "Barotrauma",
     "author": "admin@softwarenoob.com",
     "description": "Barotrauma is a 2D co-op survival horror submarine simulator, inspired by games like FTL: Faster Than Light, Rimworld, Dwarf Fortress and Space Station 13. It\u2019s a Sci-Fi game that combines ragdoll physics and alien sea monsters with teamwork and existential fear.",
-    "features": null,
+    "features": [
+        "steam_disk_space"
+    ],
     "images": [
         "ghcr.io\/parkervcp\/games:source"
     ],

--- a/game_eggs/steamcmd_servers/citadel/egg-citadel-forged-with-fire.json
+++ b/game_eggs/steamcmd_servers/citadel/egg-citadel-forged-with-fire.json
@@ -8,7 +8,9 @@
     "name": "Citadel: Forged with Fire",
     "author": "info@goover.de",
     "description": "Citadel: Forged With Fire is a massive online sandbox RPG set in the mystical world of Ignus. Featuring magic, spellcasting, building, exploring and crafting as you fight to make a name for yourself and achieve notoriety across the land.",
-    "features": null,
+    "features": [
+        "steam_disk_space"
+    ],
     "images": [
         "ghcr.io\/parkervcp\/games:source"
     ],

--- a/game_eggs/steamcmd_servers/conan_exiles/egg-conan-exiles.json
+++ b/game_eggs/steamcmd_servers/conan_exiles/egg-conan-exiles.json
@@ -1,13 +1,20 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
-        "version": "PTDL_v1"
+        "version": "PTDL_v1",
+        "update_url": null
     },
-    "exported_at": "2020-10-24T11:25:01+00:00",
+    "exported_at": "2022-01-20T12:47:23-05:00",
     "name": "Conan Exiles",
     "author": "brycea@terrahost.cloud",
     "description": "Conan Exiles is an open-world survival game set in the brutal lands of Conan the Barbarian. Survive in a savage world, build your kingdom, and dominate your enemies in brutal combat and epic warfare.",
-    "image": "quay.io\/parkervcp\/pterodactyl-images:debian_wine-5",
+    "features": [
+        "steam_disk_space"
+    ],
+    "images": [
+        "quay.io\/parkervcp\/pterodactyl-images:debian_wine-5"
+    ],
+    "file_denylist": [],
     "startup": "xvfb-run --auto-servernum wine \/home\/container\/ConanSandboxServer.exe -console -log -Port={{SERVER_PORT}} -QueryPort={{QUERY_PORT}}",
     "config": {
         "files": "{}",
@@ -17,7 +24,7 @@
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/bash\r\n# steamcmd Base Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\n# Image to install with is 'debian:buster-slim'\r\napt -y update\r\napt -y --no-install-recommends install curl lib32gcc1 ca-certificates\r\n\r\n## just in case someone removed the defaults.\r\nif [ \"${STEAM_USER}\" == \"\" ]; then\r\n    echo -e \"steam user is not set.\\n\"\r\n    echo -e \"Using anonymous user.\\n\"\r\n    STEAM_USER=anonymous\r\n    STEAM_PASS=\"\"\r\n    STEAM_AUTH=\"\"\r\nelse\r\n    echo -e \"user set to ${STEAM_USER}\"\r\nfi\r\n\r\n## download and install steamcmd\r\ncd \/tmp\r\nmkdir -p \/mnt\/server\/steamcmd\r\ncurl -sSL -o steamcmd.tar.gz https:\/\/steamcdn-a.akamaihd.net\/client\/installer\/steamcmd_linux.tar.gz\r\ntar -xzvf steamcmd.tar.gz -C \/mnt\/server\/steamcmd\r\ncd \/mnt\/server\/steamcmd\r\n\r\n# SteamCMD fails otherwise for some reason, even running as root.\r\n# This is changed at the end of the install process anyways.\r\nchown -R root:root \/mnt\r\nexport HOME=\/mnt\/server\r\n\r\n## install game using steamcmd\r\n.\/steamcmd.sh +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} +@sSteamCmdForcePlatformType windows +force_install_dir \/mnt\/server +app_update ${SRCDS_APPID} ${EXTRA_FLAGS} validate +quit ## other flags may be needed depending on install. looking at you cs 1.6\r\n\r\n## set up 32 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk32\r\ncp -v linux32\/steamclient.so ..\/.steam\/sdk32\/steamclient.so\r\n\r\n## set up 64 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk64\r\ncp -v linux64\/steamclient.so ..\/.steam\/sdk64\/steamclient.so",
+            "script": "#!\/bin\/bash\r\n# steamcmd Base Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\n# Image to install with is 'debian:buster-slim'\r\napt -y update\r\napt -y --no-install-recommends install curl lib32gcc1 ca-certificates\r\n\r\n## just in case someone removed the defaults.\r\nif [ \"${STEAM_USER}\" == \"\" ]; then\r\n    echo -e \"steam user is not set.\\n\"\r\n    echo -e \"Using anonymous user.\\n\"\r\n    STEAM_USER=anonymous\r\n    STEAM_PASS=\"\"\r\n    STEAM_AUTH=\"\"\r\nelse\r\n    echo -e \"user set to ${STEAM_USER}\"\r\nfi\r\n\r\n## download and install steamcmd\r\ncd \/tmp\r\nmkdir -p \/mnt\/server\/steamcmd\r\ncurl -sSL -o steamcmd.tar.gz https:\/\/steamcdn-a.akamaihd.net\/client\/installer\/steamcmd_linux.tar.gz\r\ntar -xzvf steamcmd.tar.gz -C \/mnt\/server\/steamcmd\r\ncd \/mnt\/server\/steamcmd\r\n\r\n# SteamCMD fails otherwise for some reason, even running as root.\r\n# This is changed at the end of the install process anyways.\r\nchown -R root:root \/mnt\r\nexport HOME=\/mnt\/server\r\n\r\n## install game using steamcmd\r\n.\/steamcmd.sh +force_install_dir \/mnt\/server +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} +@sSteamCmdForcePlatformType windows +app_update ${SRCDS_APPID} ${EXTRA_FLAGS} validate +quit ## other flags may be needed depending on install. looking at you cs 1.6\r\n\r\n## set up 32 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk32\r\ncp -v linux32\/steamclient.so ..\/.steam\/sdk32\/steamclient.so\r\n\r\n## set up 64 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk64\r\ncp -v linux64\/steamclient.so ..\/.steam\/sdk64\/steamclient.so",
             "container": "debian:buster-slim",
             "entrypoint": "bash"
         }

--- a/game_eggs/steamcmd_servers/craftopia/egg-craftopia.json
+++ b/game_eggs/steamcmd_servers/craftopia/egg-craftopia.json
@@ -8,7 +8,9 @@
     "name": "Craftopia",
     "author": "info@goover.de",
     "description": "Craftopia is the brand new multiplayer survival action game made in Japan. We combined many features we find enjoyable, such as hunting, farming, hack-and-slash, building, automation to develop this game.",
-    "features": null,
+    "features": [
+        "steam_disk_space"
+    ],
     "images": [
         "ghcr.io\/parkervcp\/games:source"
     ],

--- a/game_eggs/steamcmd_servers/cryofall/egg-cryo-fall.json
+++ b/game_eggs/steamcmd_servers/cryofall/egg-cryo-fall.json
@@ -8,7 +8,9 @@
     "name": "CryoFall",
     "author": "contact@zennodes.dk",
     "description": "NOTE: For now you have to change SettingsServer.xml under CryoFall_Server_v(Version)_NetCore\/Data\/SettingsServer.xml\r\n\r\nCryoFall is a sci-fi multiplayer colony simulation survival game set on a forgotten planet in a distant future.\r\n\r\nJoin the vast world of CryoFall together with other survivors to rebuild your civilization from scratch. Start with primitive technology and simple tools and use them to progress towards modern industrial might and even beyond, eventually reaching space-age technology only seen in science fiction.\r\n\r\nCryoFall can be played either as a relaxed PvE experience with no competition or as a brutal and unforgiving PvP. Make your choice and join one of many available servers with different game modes or host your own and invite your friends to join you!\r\n\r\nBuild your house or a large base together with other players. Dig wells and create farms to sustain basic needs. Build vehicles to explore the world faster. Establish basics of science, all the way from medicine and chemistry to fuel creation and even lithium extraction to create electronic devices. Cook food or prepare drinks to sell them from vending machines in your store.\r\n\r\nBuild factories to produce on an industrial scale: Weapons and defense systems, bionic implants to augment yourself, even large war machines and artillery guns to use against the biggest of opponents",
-    "features": null,
+    "features": [
+        "steam_disk_space"
+    ],
     "images": [
         "ghcr.io\/parkervcp\/yolks:dotnet_5"
     ],

--- a/game_eggs/steamcmd_servers/dont_starve/egg-don-t-starve-together.json
+++ b/game_eggs/steamcmd_servers/dont_starve/egg-don-t-starve-together.json
@@ -8,7 +8,9 @@
     "name": "Don't Starve Together",
     "author": "parker@parkervcp.com",
     "description": "Don\u2019t Starve Together is an uncompromising wilderness survival game full of science and magic.",
-    "features": null,
+    "features": [
+        "steam_disk_space"
+    ],
     "images": [
         "quay.io\/parkervcp\/pterodactyl-images:debian_source"
     ],

--- a/game_eggs/steamcmd_servers/eco/egg-eco.json
+++ b/game_eggs/steamcmd_servers/eco/egg-eco.json
@@ -8,7 +8,9 @@
     "name": "Eco",
     "author": "info@goover.de",
     "description": "Eco is an online world from Strange Loop Games where players must build civilization using resources from an ecosystem that can be damaged and destroyed. The world of Eco is an incredibly reactive one, and whatever any player does in the world affects the underlying ecosystem.",
-    "features": null,
+    "features": [
+        "steam_disk_space"
+    ],
     "images": [
         "quay.io\/parkervcp\/pterodactyl-images:debian_dotnet-5"
     ],

--- a/game_eggs/steamcmd_servers/fof/egg-fof.json
+++ b/game_eggs/steamcmd_servers/fof/egg-fof.json
@@ -8,7 +8,9 @@
     "name": "Fof",
     "author": "avalongamecs@gmail.com",
     "description": "Fistful of Frags",
-    "features": null,
+    "features": [
+        "steam_disk_space"
+    ],
     "images": [
         "quay.io\/pterodactyl\/core:source"
     ],

--- a/game_eggs/steamcmd_servers/hlds_server/egg-custom-h-l-d-s-engine-game.json
+++ b/game_eggs/steamcmd_servers/hlds_server/egg-custom-h-l-d-s-engine-game.json
@@ -1,23 +1,30 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
-        "version": "PTDL_v1"
+        "version": "PTDL_v1",
+        "update_url": null
     },
-    "exported_at": "2019-06-28T20:41:35-04:00",
+    "exported_at": "2022-01-20T12:52:11-05:00",
     "name": "Custom HLDS Engine Game",
     "author": "parker@parkervcp.com",
     "description": "This option allows modifying the startup arguments and other details to run a custom HLDS based game on the panel.",
-    "image": "quay.io\/parkervcp\/pterodactyl-images:ubuntu_source",
+    "features": [
+        "steam_disk_space"
+    ],
+    "images": [
+        "quay.io\/parkervcp\/pterodactyl-images:ubuntu_source"
+    ],
+    "file_denylist": [],
     "startup": ".\/hlds_run -console -game {{HLDS_GAME}} -port {{SERVER_PORT}} -sport {{VAC_PORT}} +map {{SRCDS_MAP}} +ip 0.0.0.0 -strictportbind -norestart",
     "config": {
         "files": "{}",
-        "startup": "{\r\n    \"done\": \"Connection to Steam servers successful\",\r\n    \"userInteraction\": []\r\n}",
-        "logs": "{\r\n    \"custom\": true,\r\n    \"location\": \"logs\/latest.log\"\r\n}",
+        "startup": "{\r\n    \"done\": \"Connection to Steam servers successful\"\r\n}",
+        "logs": "{}",
         "stop": "quit"
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/bash\r\n# SRCDS Base Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\napt -y update\r\napt -y --no-install-recommends install curl lib32gcc1 ca-certificates\r\n\r\ncd \/tmp\r\ncurl -sSL -o steamcmd.tar.gz http:\/\/media.steampowered.com\/installer\/steamcmd_linux.tar.gz\r\n\r\nmkdir -p \/mnt\/server\/steamcmd\r\ntar -xzvf steamcmd.tar.gz -C \/mnt\/server\/steamcmd\r\ncd \/mnt\/server\/steamcmd\r\n\r\n# SteamCMD fails otherwise for some reason, even running as root.\r\n# This is changed at the end of the install process anyways.\r\nchown -R root:root \/mnt\r\n\r\nexport HOME=\/mnt\/server\r\n.\/steamcmd.sh +login anonymous +force_install_dir \/mnt\/server +app_update ${SRCDS_APPID} +app_set_config 90 mod ${HLDS_GAME} +quit\r\n\r\nmkdir -p \/mnt\/server\/.steam\/sdk32\r\ncp -v linux32\/steamclient.so ..\/.steam\/sdk32\/steamclient.so",
+            "script": "#!\/bin\/bash\r\n# SRCDS Base Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\napt -y update\r\napt -y --no-install-recommends install curl lib32gcc1 ca-certificates\r\n\r\ncd \/tmp\r\ncurl -sSL -o steamcmd.tar.gz http:\/\/media.steampowered.com\/installer\/steamcmd_linux.tar.gz\r\n\r\nmkdir -p \/mnt\/server\/steamcmd\r\ntar -xzvf steamcmd.tar.gz -C \/mnt\/server\/steamcmd\r\ncd \/mnt\/server\/steamcmd\r\n\r\n# SteamCMD fails otherwise for some reason, even running as root.\r\n# This is changed at the end of the install process anyways.\r\nchown -R root:root \/mnt\r\n\r\nexport HOME=\/mnt\/server\r\n.\/steamcmd.sh +force_install_dir \/mnt\/server +login anonymous +app_update ${SRCDS_APPID} +app_set_config 90 mod ${HLDS_GAME} +quit\r\n\r\nmkdir -p \/mnt\/server\/.steam\/sdk32\r\ncp -v linux32\/steamclient.so ..\/.steam\/sdk32\/steamclient.so",
             "container": "ubuntu:18.04",
             "entrypoint": "bash"
         }
@@ -28,8 +35,8 @@
             "description": "The ID corresponding to the game to download and run using HLDS.\r\n\r\nThe HLDS server ID is 90. This should not be changed.",
             "env_variable": "SRCDS_APPID",
             "default_value": "90",
-            "user_viewable": 1,
-            "user_editable": 0,
+            "user_viewable": true,
+            "user_editable": false,
             "rules": "required|numeric|digits_between:1,6"
         },
         {
@@ -37,8 +44,8 @@
             "description": "The name corresponding to the game to download and run using HLDS.\r\n\r\nall the HLDS server names are here - https:\/\/developer.valvesoftware.com\/wiki\/Dedicated_Server_Name_Enumeration",
             "env_variable": "HLDS_GAME",
             "default_value": "cstrike",
-            "user_viewable": 1,
-            "user_editable": 0,
+            "user_viewable": true,
+            "user_editable": false,
             "rules": "required|alpha_dash|between:1,100"
         },
         {
@@ -46,8 +53,8 @@
             "description": "The default map for the server.",
             "env_variable": "SRCDS_MAP",
             "default_value": "de_dust2",
-            "user_viewable": 1,
-            "user_editable": 1,
+            "user_viewable": true,
+            "user_editable": true,
             "rules": "required|string|alpha_dash"
         },
         {
@@ -55,8 +62,8 @@
             "description": "Specifies the VAC port the server should use. Default is 26900.",
             "env_variable": "VAC_PORT",
             "default_value": "26900",
-            "user_viewable": 1,
-            "user_editable": 0,
+            "user_viewable": true,
+            "user_editable": false,
             "rules": "required|numeric|digits_between:1,5"
         }
     ]

--- a/game_eggs/steamcmd_servers/holdfast/egg-holdfast-na-w.json
+++ b/game_eggs/steamcmd_servers/holdfast/egg-holdfast-na-w.json
@@ -1,18 +1,25 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
-        "version": "PTDL_v1"
+        "version": "PTDL_v1",
+        "update_url": null
     },
-    "exported_at": "2020-10-18T19:13:53-04:00",
+    "exported_at": "2022-01-20T12:53:50-05:00",
     "name": "Holdfast NaW",
     "author": "ankit@bmghosting.com",
     "description": "Holdfast: Nations at War",
-    "image": "bmghosting\/pterodactyl-holdfast",
+    "features": [
+        "steam_disk_space"
+    ],
+    "images": [
+        "bmghosting\/pterodactyl-holdfast"
+    ],
+    "file_denylist": [],
     "startup": "\".\/holdfastnaw-dedicated\/Holdfast NaW\" -startserver -batchmode -nographics -screen-width 320 -screen-height 240 -screen-quality Fastest -framerate {{FPSMAX}} --serverheadless -serverConfigFilePath holdfastnaw-dedicated\/configs\/{{SERVER_CONFIG_PATH}} -logFile holdfastnaw-dedicated\/logs_output\/output_{{SERVER_CONFIG_PATH}} -logArchivesDirectory holdfastnaw-dedicated\/{{SERVER_LOG_ARCHIVE_PATH}}\/ -adminCommandsLogFilePath holdfastnaw-dedicated\/logs_adminactions\/admin_{{SERVER_CONFIG_PATH}} -playersLogFilePath holdfastnaw-dedicated\/logs_playerlogin\/players_{{SERVER_CONFIG_PATH}} -scoreboardLogFilePath holdfastnaw-dedicated\/logs_score\/scorelog_{{SERVER_CONFIG_PATH}} -chatLogFilePath holdfastnaw-dedicated\/logs_chat\/chatlog_{{SERVER_CONFIG_PATH}} -workshopDataPath holdfastnaw-dedicated\/workshop -micSpammersPlayersFilePath holdfastnaw-dedicated\/micspammers.txt -mutedVoipPlayersFilePath holdfastnaw-dedicated\/mutedplayersvoip.txt -mutedChatPlayersFilePath holdfastnaw-dedicated\/mutedplayerschat.txt -bannedPlayersFilePath holdfastnaw-dedicated\/bannedplayers.txt -p {{SERVER_PORT}} -l \"94.130.66.231\" -o 7101",
     "config": {
         "files": "{}",
-        "startup": "{\r\n    \"done\": \"STEAMAPPS_INTERFACE_VERSION008\",\r\n    \"userInteraction\": []\r\n}",
-        "logs": "{\r\n    \"custom\": true,\r\n    \"location\": \"logs\/latest.log\"\r\n}",
+        "startup": "{\r\n    \"done\": \"STEAMAPPS_INTERFACE_VERSION008\"\r\n}",
+        "logs": "{}",
         "stop": "^C"
     },
     "scripts": {

--- a/game_eggs/steamcmd_servers/hurtworld/egg-hurtworld.json
+++ b/game_eggs/steamcmd_servers/hurtworld/egg-hurtworld.json
@@ -1,23 +1,30 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
-        "version": "PTDL_v1"
+        "version": "PTDL_v1",
+        "update_url": null
     },
-    "exported_at": "2020-04-16T20:41:27-04:00",
+    "exported_at": "2022-01-20T12:55:06-05:00",
     "name": "Hurtworld",
     "author": "brycea@terrahost.cloud",
     "description": "Hurtworld is a hardcore multiplayer survival FPS with a focus on deep survival progression that doesn't become trivial once you establish some basic needs. Built for hardcore gamers, Hurtworld aims to punish.",
-    "image": "quay.io\/parkervcp\/pterodactyl-images:debian_source",
+    "features": [
+        "steam_disk_space"
+    ],
+    "images": [
+        "quay.io\/parkervcp\/pterodactyl-images:debian_source"
+    ],
+    "file_denylist": [],
     "startup": ".\/Hurtworld.x86_64 -batchmode -nographics -exec \"host {{SERVER_PORT}};queryport {{QUERY_PORT}};maxplayers {{MAX_PLAYERS}};servername {{HOSTNAME}};creativemode ${CREATIVE_MODE};${ADMINS}\" -logfile $1",
     "config": {
         "files": "{}",
         "startup": "{\r\n    \"done\": \"orphaned items\"\r\n}",
-        "logs": "{\r\n    \"custom\": true,\r\n    \"location\": \"logs\/latest.log\"\r\n}",
+        "logs": "{}",
         "stop": "^C"
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/bash\r\n# steamcmd Base Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\n# Image to install with is 'debian:buster-slim'\r\napt -y update\r\napt -y --no-install-recommends install curl lib32gcc1 ca-certificates\r\n\r\n## just in case someone removed the defaults.\r\nif [ \"${STEAM_USER}\" == \"\" ]; then\r\n    echo -e \"steam user is not set.\\n\"\r\n    echo -e \"Using anonymous user.\\n\"\r\n    STEAM_USER=anonymous\r\n    STEAM_PASS=\"\"\r\n    STEAM_AUTH=\"\"\r\nelse\r\n    echo -e \"user set to ${STEAM_USER}\"\r\nfi\r\n\r\n## download and install steamcmd\r\ncd \/tmp\r\nmkdir -p \/mnt\/server\/steamcmd\r\ncurl -sSL -o steamcmd.tar.gz https:\/\/steamcdn-a.akamaihd.net\/client\/installer\/steamcmd_linux.tar.gz\r\ntar -xzvf steamcmd.tar.gz -C \/mnt\/server\/steamcmd\r\ncd \/mnt\/server\/steamcmd\r\n\r\n# SteamCMD fails otherwise for some reason, even running as root.\r\n# This is changed at the end of the install process anyways.\r\nchown -R root:root \/mnt\r\nexport HOME=\/mnt\/server\r\n\r\n## install game using steamcmd\r\n.\/steamcmd.sh +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} +force_install_dir \/mnt\/server +app_update ${SRCDS_APPID} ${EXTRA_FLAGS} validate +quit ## other flags may be needed depending on install. looking at you cs 1.6\r\n\r\n## set up 32 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk32\r\ncp -v linux32\/steamclient.so ..\/.steam\/sdk32\/steamclient.so\r\n\r\n## set up 64 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk64\r\ncp -v linux64\/steamclient.so ..\/.steam\/sdk64\/steamclient.so",
+            "script": "#!\/bin\/bash\r\n# steamcmd Base Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\n# Image to install with is 'debian:buster-slim'\r\napt -y update\r\napt -y --no-install-recommends install curl lib32gcc1 ca-certificates\r\n\r\n## just in case someone removed the defaults.\r\nif [ \"${STEAM_USER}\" == \"\" ]; then\r\n    echo -e \"steam user is not set.\\n\"\r\n    echo -e \"Using anonymous user.\\n\"\r\n    STEAM_USER=anonymous\r\n    STEAM_PASS=\"\"\r\n    STEAM_AUTH=\"\"\r\nelse\r\n    echo -e \"user set to ${STEAM_USER}\"\r\nfi\r\n\r\n## download and install steamcmd\r\ncd \/tmp\r\nmkdir -p \/mnt\/server\/steamcmd\r\ncurl -sSL -o steamcmd.tar.gz https:\/\/steamcdn-a.akamaihd.net\/client\/installer\/steamcmd_linux.tar.gz\r\ntar -xzvf steamcmd.tar.gz -C \/mnt\/server\/steamcmd\r\ncd \/mnt\/server\/steamcmd\r\n\r\n# SteamCMD fails otherwise for some reason, even running as root.\r\n# This is changed at the end of the install process anyways.\r\nchown -R root:root \/mnt\r\nexport HOME=\/mnt\/server\r\n\r\n## install game using steamcmd\r\n.\/steamcmd.sh +force_install_dir \/mnt\/server +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} +app_update ${SRCDS_APPID} ${EXTRA_FLAGS} validate +quit ## other flags may be needed depending on install. looking at you cs 1.6\r\n\r\n## set up 32 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk32\r\ncp -v linux32\/steamclient.so ..\/.steam\/sdk32\/steamclient.so\r\n\r\n## set up 64 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk64\r\ncp -v linux64\/steamclient.so ..\/.steam\/sdk64\/steamclient.so",
             "container": "debian:buster-slim",
             "entrypoint": "bash"
         }
@@ -28,8 +35,8 @@
             "description": "The ID corresponding to the game to download and run using SRCDS.",
             "env_variable": "SRCDS_APPID",
             "default_value": "405100",
-            "user_viewable": 1,
-            "user_editable": 0,
+            "user_viewable": true,
+            "user_editable": false,
             "rules": "required|regex:\/^(405100)$\/"
         },
         {
@@ -37,8 +44,8 @@
             "description": "Server Query Default Port",
             "env_variable": "QUERY_PORT",
             "default_value": "13871",
-            "user_viewable": 1,
-            "user_editable": 0,
+            "user_viewable": true,
+            "user_editable": false,
             "rules": "required|string"
         },
         {
@@ -46,8 +53,8 @@
             "description": "Max players allowed on the server at one time.",
             "env_variable": "MAX_PLAYERS",
             "default_value": "60",
-            "user_viewable": 1,
-            "user_editable": 1,
+            "user_viewable": true,
+            "user_editable": true,
             "rules": "required|string|max:60"
         },
         {
@@ -55,8 +62,8 @@
             "description": "The name of your server in the public server list.",
             "env_variable": "HOSTNAME",
             "default_value": "A Hurtworld Server",
-            "user_viewable": 1,
-            "user_editable": 1,
+            "user_viewable": true,
+            "user_editable": true,
             "rules": "required|string|max:50"
         }
     ]

--- a/game_eggs/steamcmd_servers/insurgency_sandstorm/egg-insurgency--sandstorm.json
+++ b/game_eggs/steamcmd_servers/insurgency_sandstorm/egg-insurgency--sandstorm.json
@@ -8,7 +8,9 @@
     "name": "Insurgency: Sandstorm",
     "author": "brycea@terrahost.cloud",
     "description": "Insurgency: Sandstorm is a team-based, tactical FPS based on lethal close quarters combat and objective-oriented multiplayer gameplay. Experience the intensity of modern combat where skill is rewarded, and teamwork wins the fight.",
-    "features": null,
+    "features": [
+        "steam_disk_space"
+    ],
     "images": [
         "ghcr.io\/parkervcp\/games:source"
     ],

--- a/game_eggs/steamcmd_servers/killing_floor_2/egg-killing-floor2.json
+++ b/game_eggs/steamcmd_servers/killing_floor_2/egg-killing-floor2.json
@@ -8,7 +8,9 @@
     "name": "Killing Floor 2",
     "author": "parker@parkervcp.com",
     "description": "In KILLING FLOOR 2, players descend into continental Europe after it has been overrun by horrific, murderous clones called Zeds that were created by the corporation Horzine. The Zed outbreak caused by Horzine Biotech\u2019s failed experiments has quickly spread with unstoppable momentum, paralyzing the European Union. Only a month ago, the first Zed outbreak from the original KILLING FLOOR ripped through London; now the specimen clones are everywhere.",
-    "features": null,
+    "features": [
+        "steam_disk_space"
+    ],
     "images": [
         "quay.io\/parkervcp\/pterodactyl-images:debian_source"
     ],

--- a/game_eggs/steamcmd_servers/left4dead/egg-left4dead.json
+++ b/game_eggs/steamcmd_servers/left4dead/egg-left4dead.json
@@ -8,7 +8,9 @@
     "name": "Left 4 Dead",
     "author": "pterodactyl@mazoyer.eu",
     "description": "An outbreak of a highly contagious pathogen nicknamed the \"Green Flu\" begins in Pennsylvania. Two weeks after the first infection, four immune survivors, Bill, Zoey, Louis, and Francis make their way out of the city of Fairfield, only to discover that the infection is creating dangerous mutations in some of its hosts.",
-    "features": null,
+    "features": [
+        "steam_disk_space"
+    ],
     "images": [
         "ghcr.io\/parkervcp\/games:source"
     ],

--- a/game_eggs/steamcmd_servers/left4dead_2/egg-left4dead_2.json
+++ b/game_eggs/steamcmd_servers/left4dead_2/egg-left4dead_2.json
@@ -8,7 +8,9 @@
     "name": "Left 4 Dead 2",
     "author": "pterodactyl@mazoyer.eu",
     "description": "Left 4 Dead 2 is set in the aftermath of a worldwide pandemic of a disease nicknamed the \"Green Flu\", which rapidly transforms humans into zombie-like creatures and mutated forms that demonstrate extreme aggression towards non-infected beings. A few humans are immune to the disease, while some of those who are infected have no symptoms. The Civil Emergency and Defense Agency (CEDA) and the U.S. military create safe zones to attempt to evacuate as many survivors as possible.",
-    "features": null,
+    "features": [
+        "steam_disk_space"
+    ],
     "images": [
         "ghcr.io\/parkervcp\/games:source"
     ],

--- a/game_eggs/steamcmd_servers/modiverse/egg-modiverse.json
+++ b/game_eggs/steamcmd_servers/modiverse/egg-modiverse.json
@@ -8,7 +8,9 @@
     "name": "Modiverse",
     "author": "admin@softwarenoob.com",
     "description": "Modiverse provides a sandbox environment with the ability to create and play mods such as TTT, Deathrun, FortWars, RP, and more! Use the many sandbox tools to build complex worlds with props, lights, thrusters, wheels, and much much more!",
-    "features": null,
+    "features": [
+        "steam_disk_space"
+    ],
     "images": [
         "quay.io\/parkervcp\/pterodactyl-images:ubuntu_source"
     ],

--- a/game_eggs/steamcmd_servers/mordhau/egg-mordhau-wine.json
+++ b/game_eggs/steamcmd_servers/mordhau/egg-mordhau-wine.json
@@ -8,7 +8,9 @@
     "name": "Mordhau Wine",
     "author": "parker@parkervcp.com",
     "description": "Mordhau is a multiplayer medieval hack 'n slash video game, developed by Slovenian independent studio Triternion, with a prominent aspect of skill-based competitive play and customization.",
-    "features": null,
+    "features": [
+        "steam_disk_space"
+    ],
     "images": [
         "quay.io\/parkervcp\/pterodactyl-images:debian_wine"
     ],

--- a/game_eggs/steamcmd_servers/mordhau/egg-mordhau.json
+++ b/game_eggs/steamcmd_servers/mordhau/egg-mordhau.json
@@ -8,7 +8,9 @@
     "name": "Mordhau",
     "author": "trey@chazx.cc",
     "description": "Mordhau is a multiplayer medieval hack 'n slash video game, developed by Slovenian independent studio Triternion, with a prominent aspect of skill-based competitive play and customization.",
-    "features": null,
+    "features": [
+        "steam_disk_space"
+    ],
     "images": [
         "quay.io\/parkervcp\/pterodactyl-images:game_mordhau"
     ],

--- a/game_eggs/steamcmd_servers/nmrih/egg-nmrih.json
+++ b/game_eggs/steamcmd_servers/nmrih/egg-nmrih.json
@@ -8,7 +8,9 @@
     "name": "nmrih",
     "author": "avalongamecs@gmail.com",
     "description": "No More Room In Hell",
-    "features": null,
+    "features": [
+        "steam_disk_space"
+    ],
     "images": [
         "quay.io\/pterodactyl\/core:source"
     ],

--- a/game_eggs/steamcmd_servers/onset/egg-onset.json
+++ b/game_eggs/steamcmd_servers/onset/egg-onset.json
@@ -1,17 +1,24 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
-        "version": "PTDL_v1"
+        "version": "PTDL_v1",
+        "update_url": null
     },
-    "exported_at": "2019-12-12T18:56:28-05:00",
+    "exported_at": "2022-01-20T12:56:32-05:00",
     "name": "Onset",
     "author": "parker@parkervcp.com",
     "description": "Onset is an open world multiplayer sandbox without predefined goals. Create and host your very own experience in Onset using scripting functions. Whether that is Roleplay, Cops and Robbers or classic Freeroam. Or just enjoy the different gamemodes created by other players.",
-    "image": "quay.io\/parkervcp\/pterodactyl-images:ubuntu_source",
+    "features": [
+        "steam_disk_space"
+    ],
+    "images": [
+        "quay.io\/parkervcp\/pterodactyl-images:ubuntu_source"
+    ],
+    "file_denylist": [],
     "startup": ".\/OnsetServer --noinput",
     "config": {
-        "files": "{\r\n    \"server_config.json\": {\r\n        \"parser\": \"json\",\r\n        \"find\": {\r\n            \"ipaddress\": \"0.0.0.0\",\r\n            \"port\": \"{{server.build.default.port}}\",\r\n            \"servername\": \"{{server.build.env.SERVER_NAME}}\",\r\n            \"password\":\"{{server.build.env.SERVER_PASSWORD}}\"\r\n        }\r\n    }\r\n}",
-        "startup": "{\r\n    \"done\": \"Entering simulation\",\r\n    \"userInteraction\": []\r\n}",
+        "files": "{\r\n    \"server_config.json\": {\r\n        \"parser\": \"json\",\r\n        \"find\": {\r\n            \"ipaddress\": \"0.0.0.0\",\r\n            \"port\": \"{{server.build.default.port}}\",\r\n            \"servername\": \"{{server.build.env.SERVER_NAME}}\",\r\n            \"password\": \"{{server.build.env.SERVER_PASSWORD}}\"\r\n        }\r\n    }\r\n}",
+        "startup": "{\r\n    \"done\": \"Entering simulation\"\r\n}",
         "logs": "{}",
         "stop": "^C"
     },
@@ -28,8 +35,8 @@
             "description": "ARK steam app id for auto updates. Leave blank to avoid auto update.",
             "env_variable": "SRCDS_APPID",
             "default_value": "1204170",
-            "user_viewable": 1,
-            "user_editable": 0,
+            "user_viewable": true,
+            "user_editable": false,
             "rules": "required|string|max:20"
         },
         {
@@ -37,8 +44,8 @@
             "description": "required to load server libraries.",
             "env_variable": "LD_LIBRARY_PATH",
             "default_value": ".",
-            "user_viewable": 0,
-            "user_editable": 0,
+            "user_viewable": false,
+            "user_editable": false,
             "rules": "required|string|max:20"
         },
         {
@@ -46,8 +53,8 @@
             "description": "This flag will auto update the server on restart. (default is 1) \r\n\r\nSet to 1 to update\r\nSet to 0 to no update",
             "env_variable": "AUTO_UPDATE",
             "default_value": "1",
-            "user_viewable": 1,
-            "user_editable": 1,
+            "user_viewable": true,
+            "user_editable": true,
             "rules": "required|string|max:20"
         }
     ]

--- a/game_eggs/steamcmd_servers/pavlov_vr/egg-pavlov-v-r.json
+++ b/game_eggs/steamcmd_servers/pavlov_vr/egg-pavlov-v-r.json
@@ -8,7 +8,9 @@
     "name": "Pavlov VR",
     "author": "admin@devil.wtf",
     "description": "Pavlov VR is a multiplayer shooter in VR with heavy focus on community features. Realistic reloading features and fast paced combat as part of the core experience. Play the #1 most popular VR shooter on PC today.",
-    "features": null,
+    "features": [
+        "steam_disk_space"
+    ],
     "images": [
         "quay.io\/parkervcp\/pterodactyl-images:debian_source"
     ],

--- a/game_eggs/steamcmd_servers/pixark/egg-pix-a-r-k.json
+++ b/game_eggs/steamcmd_servers/pixark/egg-pix-a-r-k.json
@@ -8,7 +8,9 @@
     "name": "PixARK",
     "author": "hello@venatus.digital",
     "description": "A simple Docker container with Wine to run PixARK using Pterodactyl Panel",
-    "features": null,
+    "features": [
+        "steam_disk_space"
+    ],
     "images": [
         "quay.io\/parkervcp\/pterodactyl-images:ubuntu_wine-source"
     ],

--- a/game_eggs/steamcmd_servers/post_scriptum/egg-post-scriptum.json
+++ b/game_eggs/steamcmd_servers/post_scriptum/egg-post-scriptum.json
@@ -8,7 +8,9 @@
     "name": "Post Scriptum",
     "author": "admin@softwarenoob.com",
     "description": "Post Scriptum is a WW2-themed first-person tactical shooter that provides an authentic WWII combat experience. Focusing on historical accuracy, large-scale battles, and a challenging battlefield demands an intense need for cohesion, communication, and teamwork.",
-    "features": null,
+    "features": [
+        "steam_disk_space"
+    ],
     "images": [
         "quay.io\/pterodactyl\/core:source"
     ],

--- a/game_eggs/steamcmd_servers/project_zomboid/egg-project-zomboid.json
+++ b/game_eggs/steamcmd_servers/project_zomboid/egg-project-zomboid.json
@@ -8,7 +8,9 @@
     "name": "Project Zomboid",
     "author": "iamkubi@gmail.com",
     "description": "Project Zomboid is an open world survival horror video game in alpha stage development by British and Canadian independent developer, The Indie Stone. The game is set in a post apocalyptic, zombie infested world where the player is challenged to survive for as long as possible before inevitably dying.",
-    "features": null,
+    "features": [
+        "steam_disk_space"
+    ],
     "images": [
         "ghcr.io\/pterodactyl\/games:source"
     ],

--- a/game_eggs/steamcmd_servers/quake_live/egg-quake-live.json
+++ b/game_eggs/steamcmd_servers/quake_live/egg-quake-live.json
@@ -7,7 +7,9 @@
     "name": "Quake Live",
     "author": "patz.michael@gmail.com",
     "description": "Quake Live is a first-person shooter video game by id Software. It is an updated version of Quake III Arena that was originally designed as a free-to-play game launched via a web browser plug-in. On September 17, 2014, the game was re-launched as a standalone title on Steam.",
-    "features": null,
+    "features": [
+        "steam_disk_space"
+    ],
     "image": "quay.io\/parkervcp\/pterodactyl-images:ubuntu_source",
     "startup": ".\/qzeroded.x64  +set net_port \"{{SERVER_PORT}}\" +set sv_hostname \"{{SERVER_NAME}}\" +set sv_serverType \"{{SERVER_TYPE}}\" +set g_password \"{{PASSWORD}}\" +sv_fps \"{{FPS}}\"",
     "config": {

--- a/game_eggs/steamcmd_servers/rising_world/egg-rising-world.json
+++ b/game_eggs/steamcmd_servers/rising_world/egg-rising-world.json
@@ -8,7 +8,9 @@
     "name": "Rising World",
     "author": "info@goover.de",
     "description": "Rising World is a voxel based open-world sandbox game, featuring a procedurally generated world, playable in single and multi-player.",
-    "features": null,
+    "features": [
+        "steam_disk_space"
+    ],
     "images": [
         "quay.io\/pterodactyl\/core:java"
     ],

--- a/game_eggs/steamcmd_servers/risk_of_rain_2/egg-risk-of-rain2.json
+++ b/game_eggs/steamcmd_servers/risk_of_rain_2/egg-risk-of-rain2.json
@@ -8,7 +8,9 @@
     "name": "Risk of Rain 2",
     "author": "alex.chang-lam@protonmail.com",
     "description": "Risk of Rain 2 dedicated server.",
-    "features": null,
+    "features": [
+        "steam_disk_space"
+    ],
     "images": [
         "quay.io\/parkervcp\/pterodactyl-images:debian_wine-5"
     ],

--- a/game_eggs/steamcmd_servers/rust/rust_autowipe/egg-rust-autowipe.json
+++ b/game_eggs/steamcmd_servers/rust/rust_autowipe/egg-rust-autowipe.json
@@ -8,7 +8,9 @@
     "name": "Rust Autowipe",
     "author": "support@pterodactyl.io",
     "description": "The only aim in Rust is to survive. To do this you will need to overcome struggles such as hunger, thirst and cold. Build a fire. Build a shelter. Kill animals for meat. Protect yourself from other players, and kill them for meat. Create alliances with other players and form a town. Do whatever it takes to survive.",
-    "features": null,
+    "features": [
+        "steam_disk_space"
+    ],
     "images": [
         "quay.io\/pterodactyl\/core:rust"
     ],

--- a/game_eggs/steamcmd_servers/rust/rust_staging/egg-rust-staging.json
+++ b/game_eggs/steamcmd_servers/rust/rust_staging/egg-rust-staging.json
@@ -8,7 +8,9 @@
     "name": "Rust Staging",
     "author": "root@smc.li",
     "description": "The only aim in Rust is to survive. To do this you will need to overcome struggles such as hunger, thirst and cold. Build a fire. Build a shelter. Kill animals for meat. Protect yourself from other players, and kill them for meat. Create alliances with other players and form a town. Do whatever it takes to survive.",
-    "features": null,
+    "features": [
+        "steam_disk_space"
+    ],
     "images": [
         "quay.io\/pterodactyl\/core:rust"
     ],

--- a/game_eggs/steamcmd_servers/satisfactory/egg-satisfactory.json
+++ b/game_eggs/steamcmd_servers/satisfactory/egg-satisfactory.json
@@ -7,7 +7,9 @@
     "name": "Satisfactory",
     "author": "rehlmgaming@gmail.com",
     "description": "Satisfactory is a first-person open-world factory building game with a dash of exploration and combat. Play alone or with friends, explore an alien planet, create multi-story factories, and enter conveyor belt heaven!",
-    "features": null,
+    "features": [
+        "steam_disk_space"
+    ],
     "images": [
         "ghcr.io\/parkervcp\/games:source"
     ],

--- a/game_eggs/steamcmd_servers/scpsl/dedicated/egg-scpsl.json
+++ b/game_eggs/steamcmd_servers/scpsl/dedicated/egg-scpsl.json
@@ -8,7 +8,9 @@
     "name": "SCP:SL",
     "author": "info@goover.de",
     "description": "Egg for SCP: Secret Laboratory Dedicated Linux Server",
-    "features": null,
+    "features": [
+        "steam_disk_space"
+    ],
     "images": [
         "ghcr.io\/parkervcp\/yolks:mono_latest"
     ],

--- a/game_eggs/steamcmd_servers/scpsl/exiled/egg-s-c-p--s-l--exiled.json
+++ b/game_eggs/steamcmd_servers/scpsl/exiled/egg-s-c-p--s-l--exiled.json
@@ -8,7 +8,9 @@
     "name": "SCP:SL - Exiled",
     "author": "info@goover.de",
     "description": "Egg for SCP: Secret Laboratory Dedicated Linux Server with Exiled Plugin Framework",
-    "features": null,
+    "features": [
+        "steam_disk_space"
+    ],
     "images": [
         "ghcr.io\/parkervcp\/yolks:mono_latest"
     ],

--- a/game_eggs/steamcmd_servers/scpsl/multiadmin/egg-s-c-p--secret-laboratory--multi-admin.json
+++ b/game_eggs/steamcmd_servers/scpsl/multiadmin/egg-s-c-p--secret-laboratory--multi-admin.json
@@ -8,7 +8,9 @@
     "name": "SCP: Secret Laboratory - MultiAdmin",
     "author": "info@goover.de",
     "description": "The latest vanilla version of SCP:SL running through MultiAdmin for compatibility. LocalAdmin does not work. No SMod2.",
-    "features": null,
+    "features": [
+        "steam_disk_space"
+    ],
     "images": [
         "ghcr.io\/parkervcp\/yolks:mono_latest"
     ],

--- a/game_eggs/steamcmd_servers/soldat/egg-soldat.json
+++ b/game_eggs/steamcmd_servers/soldat/egg-soldat.json
@@ -1,18 +1,25 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
-        "version": "PTDL_v1"
+        "version": "PTDL_v1",
+        "update_url": null
     },
-    "exported_at": "2020-10-06T16:59:53+02:00",
+    "exported_at": "2022-01-20T12:58:19-05:00",
     "name": "Soldat",
     "author": "info@goover.de",
     "description": "Soldat is a unique 2D (side-view) multiplayer action game. It has been influenced by the best of games such as Liero, Worms, Quake, and Counter-Strike and provides a fast-paced gaming experience with tons of blood and flesh. Soldiers fight against each other in 2D battle arenas using a deadly arsenal of military weapons, across 7 default game modes. It features 18 different weapons and 60 maps to frag away on, with full support for user created content.\r\n\r\nSteam: https:\/\/store.steampowered.com\/app\/638490\/Soldat\/",
-    "image": "quay.io\/parkervcp\/pterodactyl-images:base_debian",
+    "features": [
+        "steam_disk_space"
+    ],
+    "images": [
+        "quay.io\/parkervcp\/pterodactyl-images:base_debian"
+    ],
+    "file_denylist": [],
     "startup": ".\/soldatserver",
     "config": {
         "files": "{\r\n    \"soldat.ini\": {\r\n        \"parser\": \"ini\",\r\n        \"find\": {\r\n            \"NETWORK.Port\": \"{{server.build.default.port}}\",\r\n            \"NETWORK.Max_Players\": \"{{server.build.env.MAX_PLAYERS}}\",\r\n            \"NETWORK.Game_Password\": \"{{server.build.env.SRV_PWD}}\",\r\n            \"NETWORK.Admin_Password\": \"{{server.build.env.ADMIN_PASSWD}}\",\r\n            \"NETWORK.Server_Name\": \"{{server.build.env.SRV_NAME}}\"\r\n        }\r\n    }\r\n}",
-        "startup": "{\r\n    \"done\": \"Done\",\r\n    \"userInteraction\": []\r\n}",
-        "logs": "{\r\n    \"custom\": true,\r\n    \"location\": \"logs\/latest.log\"\r\n}",
+        "startup": "{\r\n    \"done\": \"Done\"\r\n}",
+        "logs": "{}",
         "stop": "^C"
     },
     "scripts": {

--- a/game_eggs/steamcmd_servers/space_engineers/egg-space-engineers.json
+++ b/game_eggs/steamcmd_servers/space_engineers/egg-space-engineers.json
@@ -8,7 +8,9 @@
     "name": "Space Engineers",
     "author": "tueye@tuworld.de",
     "description": "Space Engineers is a voxel-based sandbox game set in space and on planets.",
-    "features": null,
+    "features": [
+        "steam_disk_space"
+    ],
     "images": [
         "quay.io\/parkervcp\/pterodactyl-images:debian_wine-5"
     ],

--- a/game_eggs/steamcmd_servers/squad/egg-squad.json
+++ b/game_eggs/steamcmd_servers/squad/egg-squad.json
@@ -1,18 +1,25 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
-        "version": "PTDL_v1"
+        "version": "PTDL_v1",
+        "update_url": null
     },
-    "exported_at": "2019-10-08T08:47:08-04:00",
+    "exported_at": "2022-01-20T12:59:49-05:00",
     "name": "Squad",
     "author": "brycea@terrahost.cloud",
     "description": "Squad is a 50 vs 50 multiplayer first-person shooter that aims to capture combat realism through communication and teamplay. Major features include vehicle-based combined arms gameplay, large scale environments, base building, and integrated positional VoIP for proximity talking & radio.",
-    "image": "quay.io\/pterodactyl\/core:source",
+    "features": [
+        "steam_disk_space"
+    ],
+    "images": [
+        "quay.io\/pterodactyl\/core:source"
+    ],
+    "file_denylist": [],
     "startup": "\/home\/container\/SquadGame\/Binaries\/Linux\/SquadGameServer SquadGame Port={{SERVER_PORT}} QueryPort={{QUERY_PORT}}",
     "config": {
         "files": "{\r\n    \"SquadGame\/ServerConfig\/Server.cfg\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"ServerName\": \"ServerName=\\\"{{server.build.env.servername}}\\\"\",\r\n            \"MaxPlayers\": \"MaxPlayers={{server.build.env.maxplayers}}\",\r\n            \"AllowTeamChanges\": \"AllowTeamChanges={{server.build.env.allowteamchange}}\",\r\n            \"ShouldAdvertise\": \"ShouldAdvertise={{server.build.env.advertise}}\",\r\n            \"NumReservedSlots\": \"NumReservedSlots={{server.build.env.reservedslots}}\",\r\n            \"PreventTeamChangeIfUnbalanced\": \"PreventTeamChangeIfUnbalanced={{server.build.env.ptciu}}\",\r\n            \"EnforceTeamBalance\": \"EnforceTeamBalance={{server.build.env.teambal}}\",\r\n            \"RecordDemos\": \"RecordDemos={{server.build.env.recorddemos}}\"\r\n        }\r\n    }\r\n}",
-        "startup": "{\r\n    \"done\": \"Engine Initialization\",\r\n    \"userInteraction\": []\r\n}",
-        "logs": "{\r\n    \"custom\": false,\r\n    \"location\": \"latest.log\"\r\n}",
+        "startup": "{\r\n    \"done\": \"Engine Initialization\"\r\n}",
+        "logs": "{}",
         "stop": "^C"
     },
     "scripts": {
@@ -28,8 +35,8 @@
             "description": "Query port for your Squad server.",
             "env_variable": "QUERY_PORT",
             "default_value": "27165",
-            "user_viewable": 1,
-            "user_editable": 1,
+            "user_viewable": true,
+            "user_editable": true,
             "rules": "required|numeric"
         },
         {
@@ -37,8 +44,8 @@
             "description": "this is needed for some reason",
             "env_variable": "LD_LIBRARY_PATH",
             "default_value": "\/home\/container\/linux64\/",
-            "user_viewable": 0,
-            "user_editable": 0,
+            "user_viewable": false,
+            "user_editable": false,
             "rules": "required|string"
         },
         {
@@ -46,8 +53,8 @@
             "description": "The ID corresponding to the game to download and run using SRCDS.",
             "env_variable": "SRCDS_APPID",
             "default_value": "403240",
-            "user_viewable": 0,
-            "user_editable": 0,
+            "user_viewable": false,
+            "user_editable": false,
             "rules": "required|string|max:20"
         },
         {
@@ -55,8 +62,8 @@
             "description": "The name for the server in the server list",
             "env_variable": "servername",
             "default_value": "Squad Server",
-            "user_viewable": 1,
-            "user_editable": 1,
+            "user_viewable": true,
+            "user_editable": true,
             "rules": "required|string|max:30"
         },
         {
@@ -64,8 +71,8 @@
             "description": "Sets the maximum number of players.",
             "env_variable": "maxplayers",
             "default_value": "80",
-            "user_viewable": 1,
-            "user_editable": 1,
+            "user_viewable": true,
+            "user_editable": true,
             "rules": "required"
         },
         {
@@ -73,8 +80,8 @@
             "description": "Allow players to change teams ( true \/ false )",
             "env_variable": "allowteamchange",
             "default_value": "true",
-            "user_viewable": 1,
-            "user_editable": 1,
+            "user_viewable": true,
+            "user_editable": true,
             "rules": "required|string"
         },
         {
@@ -82,8 +89,8 @@
             "description": "Have the server report to the public server list ( true \/ false )",
             "env_variable": "advertise",
             "default_value": "true",
-            "user_viewable": 1,
-            "user_editable": 1,
+            "user_viewable": true,
+            "user_editable": true,
             "rules": "required|string"
         },
         {
@@ -91,8 +98,8 @@
             "description": "The number of reserved slots for admins \/ mods",
             "env_variable": "reservedslots",
             "default_value": "0",
-            "user_viewable": 1,
-            "user_editable": 1,
+            "user_viewable": true,
+            "user_editable": true,
             "rules": "required|string"
         },
         {
@@ -100,8 +107,8 @@
             "description": "This will prevent players from changing teams if they're already unbalanced ( true \/ false )",
             "env_variable": "ptciu",
             "default_value": "true",
-            "user_viewable": 1,
-            "user_editable": 1,
+            "user_viewable": true,
+            "user_editable": true,
             "rules": "required|string"
         },
         {
@@ -109,8 +116,8 @@
             "description": "This will FORCE team balance if the teams are too uneven ( true \/ false )",
             "env_variable": "teambal",
             "default_value": "true",
-            "user_viewable": 1,
-            "user_editable": 1,
+            "user_viewable": true,
+            "user_editable": true,
             "rules": "required|string"
         },
         {
@@ -118,8 +125,8 @@
             "description": "This will record demos of the players ( true \/ false )",
             "env_variable": "recorddemos",
             "default_value": "true",
-            "user_viewable": 1,
-            "user_editable": 1,
+            "user_viewable": true,
+            "user_editable": true,
             "rules": "required|string"
         }
     ]

--- a/game_eggs/steamcmd_servers/starbound/egg-starbound.json
+++ b/game_eggs/steamcmd_servers/starbound/egg-starbound.json
@@ -8,7 +8,9 @@
     "name": "Starbound",
     "author": "parker@parkervcp.com",
     "description": "Starbound takes place in a two-dimensional, procedurally generated universe which the player is able to explore in order to obtain new weapons, armor, and items, and to visit towns and villages inhabited by various intelligent lifeforms.",
-    "features": null,
+    "features": [
+        "steam_disk_space"
+    ],
     "images": [
         "quay.io\/parkervcp\/pterodactyl-images:ubuntu_source"
     ],

--- a/game_eggs/steamcmd_servers/stationeers/egg-stationeers.json
+++ b/game_eggs/steamcmd_servers/stationeers/egg-stationeers.json
@@ -1,18 +1,25 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
-        "version": "PTDL_v1"
+        "version": "PTDL_v1",
+        "update_url": null
     },
-    "exported_at": "2020-08-04T20:01:04-07:00",
+    "exported_at": "2022-01-20T13:00:48-05:00",
     "name": "Stationeers",
     "author": "sysadmin@whiteshield.ch",
     "description": "Stationeers Server\r\n\r\ndefault.ini will be created once you start game. Command parameters override default.ini parameters\r\nDon't forget to change the RCON Password !!\r\n\r\nRemote Administrator:\r\nYou can send commands on web browser.\r\nLink : http:\/\/[dedicated server address]:[GamePort]\r\n\r\nDedicated Server Wiki ==> https:\/\/stationeers-wiki.com\/Dedicated_Server_Guide\r\n\r\nStopping the server don't save the game, for manual save use the Remote Administrator.",
-    "image": "quay.io\/pterodactyl\/core:source",
+    "features": [
+        "steam_disk_space"
+    ],
+    "images": [
+        "quay.io\/pterodactyl\/core:source"
+    ],
+    "file_denylist": [],
     "startup": ".\/rocketstation_DedicatedServer.x86_64 -batchmode -nographics -autostart -autosaveinterval={{SAVE_INTERVAL}} -clearallinterval={{CLEAR_INTERVAL}} -worldtype={{SERVER_MAP}} -worldname={{SAVE_NAME}} -loadworld={{SAVE_NAME}} -basedirectory=\/home\/container -updateport={{UPDATE_PORT}} -gameport={{GAME_PORT}}",
     "config": {
         "files": "{}",
-        "startup": "{\r\n    \"done\": \"Dedicated Server Started\",\r\n    \"userInteraction\": []\r\n}",
-        "logs": "{\r\n    \"custom\": true,\r\n    \"location\": \"logs\/latest.log\"\r\n}",
+        "startup": "{\r\n    \"done\": \"Dedicated Server Started\"\r\n}",
+        "logs": "{}",
         "stop": "^C"
     },
     "scripts": {
@@ -28,8 +35,8 @@
             "description": "Available Maps: Moon, Mars, Europa, Vulcan, Space, Mimas, Loulan",
             "env_variable": "SERVER_MAP",
             "default_value": "Moon",
-            "user_viewable": 1,
-            "user_editable": 1,
+            "user_viewable": true,
+            "user_editable": true,
             "rules": "required|string|max:20"
         },
         {
@@ -37,8 +44,8 @@
             "description": "Sets the server\u2019s auto-save interval in seconds.",
             "env_variable": "SAVE_INTERVAL",
             "default_value": "300",
-            "user_viewable": 1,
-            "user_editable": 1,
+            "user_viewable": true,
+            "user_editable": true,
             "rules": "required|integer"
         },
         {
@@ -46,8 +53,8 @@
             "description": "Clear disconnected player interval in seconds",
             "env_variable": "CLEAR_INTERVAL",
             "default_value": "86400",
-            "user_viewable": 1,
-            "user_editable": 1,
+            "user_viewable": true,
+            "user_editable": true,
             "rules": "required|integer"
         },
         {
@@ -55,8 +62,8 @@
             "description": "Name of the save of your world.\r\nAuto save & auto load worlds on server startup.",
             "env_variable": "SAVE_NAME",
             "default_value": "stationeers_1",
-            "user_viewable": 1,
-            "user_editable": 1,
+            "user_viewable": true,
+            "user_editable": true,
             "rules": "required|string|max:20"
         },
         {
@@ -64,8 +71,8 @@
             "description": "UDP port for game. Avoid to set 27015-27020. It's steam's local server query ports.",
             "env_variable": "GAME_PORT",
             "default_value": "27500",
-            "user_viewable": 1,
-            "user_editable": 1,
+            "user_viewable": true,
+            "user_editable": true,
             "rules": "required|integer"
         },
         {
@@ -73,8 +80,8 @@
             "description": "UDP port for steam query must be between 27015-27020.",
             "env_variable": "UPDATE_PORT",
             "default_value": "27015",
-            "user_viewable": 1,
-            "user_editable": 1,
+            "user_viewable": true,
+            "user_editable": true,
             "rules": "required|integer"
         },
         {
@@ -82,8 +89,8 @@
             "description": "Required for automatic updates.",
             "env_variable": "SRCDS_APPID",
             "default_value": "600760",
-            "user_viewable": 0,
-            "user_editable": 0,
+            "user_viewable": false,
+            "user_editable": false,
             "rules": "required|string|max:20"
         }
     ]

--- a/game_eggs/steamcmd_servers/stormworks/egg-stormworks--build-and-rescue.json
+++ b/game_eggs/steamcmd_servers/stormworks/egg-stormworks--build-and-rescue.json
@@ -1,13 +1,20 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
-        "version": "PTDL_v1"
+        "version": "PTDL_v1",
+        "update_url": null
     },
-    "exported_at": "2020-10-27T03:09:48+00:00",
+    "exported_at": "2022-01-20T13:01:27-05:00",
     "name": "Stormworks: Build and Rescue",
     "author": "iamkubi@gmail.com",
     "description": "Join a world where you design, create and pilot your own air sea rescue service. Release your inner hero as you battle fierce storms out at sea to rescue those in need.",
-    "image": "quay.io\/parkervcp\/pterodactyl-images:debian_wine-5",
+    "features": [
+        "steam_disk_space"
+    ],
+    "images": [
+        "quay.io\/parkervcp\/pterodactyl-images:debian_wine-5"
+    ],
+    "file_denylist": [],
     "startup": "xvfb-run wine server.exe +server_dir \/home\/container",
     "config": {
         "files": "{}",

--- a/game_eggs/steamcmd_servers/subnautica_nitrox_mod/egg-subnautica.json
+++ b/game_eggs/steamcmd_servers/subnautica_nitrox_mod/egg-subnautica.json
@@ -8,7 +8,9 @@
     "name": "Subnautica",
     "author": "tueye@tuworld.de",
     "description": "Subnautica is an open world survival action-adventure video game developed and published by Unknown Worlds Entertainment. In it, players are free to explore the ocean on an alien planet, known as planet 4546B, after their spaceship, the Aurora, crashes on the planet's surface.\r\n\r\nNote: NitroxMod version >=1.5.0.0 is required",
-    "features": null,
+    "features": [
+        "steam_disk_space"
+    ],
     "images": [
         "quay.io\/pterodactyl\/core:mono"
     ],

--- a/game_eggs/steamcmd_servers/svencoop/egg-sven-co-op.json
+++ b/game_eggs/steamcmd_servers/svencoop/egg-sven-co-op.json
@@ -1,18 +1,25 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
-        "version": "PTDL_v1"
+        "version": "PTDL_v1",
+        "update_url": null
     },
-    "exported_at": "2019-11-14T21:43:14+01:00",
+    "exported_at": "2022-01-20T13:02:23-05:00",
     "name": "Sven Co-op",
     "author": "pteroducktyl@yildri.nl",
     "description": "Sven Co-op is a co-operative game originally based around Valve Software's Half-Life. In this game players must work together against computer controlled enemies and solve puzzles as a team.",
-    "image": "quay.io\/pterodactyl\/core:source",
+    "features": [
+        "steam_disk_space"
+    ],
+    "images": [
+        "quay.io\/pterodactyl\/core:source"
+    ],
+    "file_denylist": [],
     "startup": ".\/svends_run -console -port {{SERVER_PORT}} +maxplayers {{SC_PLAYERS}} +map {{SC_MAP}} +ip 0.0.0.0 -strictportbind -norestart",
     "config": {
         "files": "{\r\n    \"svencoop\/server.cfg\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"hostname\": \"hostname \\\"{{env.SC_NAME}}\\\"\",\r\n            \"sv_password\": \"sv_password \\\"{{env.SC_PASSWORD}}\\\"\",\r\n            \"\/\/sv_password\": \"sv_password \\\"{{env.SC_PASSWORD}}\\\"\",\r\n            \"sv_region\": \"sv_region {{env.SC_REGION}}\"\r\n        }\r\n    }\r\n}",
-        "startup": "{\r\n    \"done\": \"Connection to Steam servers successful.\",\r\n    \"userInteraction\": []\r\n}",
-        "logs": "{\r\n    \"custom\": true,\r\n    \"location\": \"logs\/latest.log\"\r\n}",
+        "startup": "{\r\n    \"done\": \"Connection to Steam servers successful.\"\r\n}",
+        "logs": "{}",
         "stop": "quit"
     },
     "scripts": {
@@ -28,8 +35,8 @@
             "description": "The default map for the server.",
             "env_variable": "SC_MAP",
             "default_value": "svencoop1",
-            "user_viewable": 1,
-            "user_editable": 1,
+            "user_viewable": true,
+            "user_editable": true,
             "rules": "required|string"
         },
         {
@@ -37,8 +44,8 @@
             "description": "The maximum amount of players that can play on the server at once.",
             "env_variable": "SC_PLAYERS",
             "default_value": "12",
-            "user_viewable": 1,
-            "user_editable": 1,
+            "user_viewable": true,
+            "user_editable": true,
             "rules": "required|numeric|between:2,32"
         },
         {
@@ -46,8 +53,8 @@
             "description": "The name your server will appear as on the in Sven Co-op in-game server list.",
             "env_variable": "SC_NAME",
             "default_value": "Sven Co-op server",
-            "user_viewable": 1,
-            "user_editable": 1,
+            "user_viewable": true,
+            "user_editable": true,
             "rules": "required|string|max:40"
         },
         {
@@ -55,8 +62,8 @@
             "description": "Password required to join the server. Leave blank to disable.",
             "env_variable": "SC_PASSWORD",
             "default_value": "",
-            "user_viewable": 1,
-            "user_editable": 1,
+            "user_viewable": true,
+            "user_editable": true,
             "rules": "nullable|string|max:20"
         },
         {
@@ -64,8 +71,8 @@
             "description": "The region your server is in. This is used in Steam's server browser, so players can look for servers near by. This does not restrict players from connecting to your server.\r\n\r\n-1: Do not list server in the server browser.\r\n0: USA east coast.\r\n1: USA west coast.\r\n2: South America (continent)\r\n3: Europe.\r\n4: Asia.\r\n5: Australia (continent, aka Oceania)\r\n6: Middle East.\r\n7: Africa.\r\n255: International.",
             "env_variable": "SC_REGION",
             "default_value": "255",
-            "user_viewable": 1,
-            "user_editable": 1,
+            "user_viewable": true,
+            "user_editable": true,
             "rules": "required|numeric|between:-1,255"
         },
         {
@@ -73,8 +80,8 @@
             "description": "Required for game to update on server restart. Do not modify this.",
             "env_variable": "SRCDS_APPID",
             "default_value": "276060",
-            "user_viewable": 0,
-            "user_editable": 0,
+            "user_viewable": false,
+            "user_editable": false,
             "rules": "required|string|max:20"
         }
     ]

--- a/game_eggs/steamcmd_servers/team_fortress_2_classic/egg-team-fortress-2-classic.json
+++ b/game_eggs/steamcmd_servers/team_fortress_2_classic/egg-team-fortress-2-classic.json
@@ -1,18 +1,25 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
-        "version": "PTDL_v1"
+        "version": "PTDL_v1",
+        "update_url": null
     },
-    "exported_at": "2020-10-13T15:32:28+01:00",
+    "exported_at": "2022-01-20T13:03:12-05:00",
     "name": "Team Fortress 2 Classic",
     "author": "eggs@scattergun.io",
     "description": "Team Fortress 2 Classic is a free mod of the 2007 game Team Fortress 2, developed by Eminoma and utilizing the Source engine.",
-    "image": "quay.io\/parkervcp\/pterodactyl-images:debian_base",
+    "features": [
+        "steam_disk_space"
+    ],
+    "images": [
+        "quay.io\/parkervcp\/pterodactyl-images:debian_base"
+    ],
+    "file_denylist": [],
     "startup": ".\/srcds_run -game {{SRCDS_GAME}} -console -port {{SERVER_PORT}} +map {{SRCDS_MAP}} +ip {{SERVER_IP}} -strictportbind -norestart -debug +maxplayers {{MAXPLAYERS}}",
     "config": {
         "files": "{}",
-        "startup": "{\r\n    \"done\": \"gameserver Steam ID\",\r\n    \"userInteraction\": []\r\n}",
-        "logs": "{\r\n    \"custom\": true,\r\n    \"location\": \"logs\/latest.log\"\r\n}",
+        "startup": "{\r\n    \"done\": \"gameserver Steam ID\"\r\n}",
+        "logs": "{}",
         "stop": "quit"
     },
     "scripts": {

--- a/game_eggs/steamcmd_servers/the_forest/egg-the-forest.json
+++ b/game_eggs/steamcmd_servers/the_forest/egg-the-forest.json
@@ -8,7 +8,9 @@
     "name": "The Forest",
     "author": "admin@softwarenoob.com",
     "description": "As the lone survivor of a passenger jet crash, you find yourself in a mysterious forest battling to stay alive against a society of cannibalistic mutants. Build, explore, survive in this terrifying first-person survival horror simulator.",
-    "features": null,
+    "features": [
+        "steam_disk_space"
+    ],
     "images": [
         "ghcr.io\/parkervcp\/yolks:wine_latest"
     ],

--- a/game_eggs/steamcmd_servers/tower_unite/egg-tower-unite.json
+++ b/game_eggs/steamcmd_servers/tower_unite/egg-tower-unite.json
@@ -1,18 +1,25 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
-        "version": "PTDL_v1"
+        "version": "PTDL_v1",
+        "update_url": null
     },
-    "exported_at": "2019-02-08T01:46:57+01:00",
+    "exported_at": "2022-01-20T13:03:59-05:00",
     "name": "Tower Unite",
     "author": "teamwuffy@gmail.com",
     "description": "Tower Unite\r\n\r\nDefault Port: 7778\r\nDefault Query Port: 27016\r\n\r\nConfig Path: Tower\/Saved\/Config\/TowerServer.ini",
-    "image": "quay.io\/pterodactyl\/core:source",
+    "features": [
+        "steam_disk_space"
+    ],
+    "images": [
+        "quay.io\/pterodactyl\/core:source"
+    ],
+    "file_denylist": [],
     "startup": ".\/Tower\/Binaries\/Linux\/TowerServer-Linux-Shipping -log -Port={{SERVER_PORT}} -MULTIHOME=0.0.0.0 -TowerServerINI=..\/..\/Saved\/Config\/TowerServer.ini",
     "config": {
         "files": "{\r\n    \"Tower\/Saved\/Config\/TowerServer.ini\": {\r\n        \"parser\": \"properties\",\r\n        \"find\": {\r\n            \"MaxPlayers\": \"{{server.build.env.SERVER_MAX_PLAYER}}\",\r\n            \"ServerTitle\": \"{{server.build.env.SERVER_TITLE}}\",\r\n            \"SteamLoginToken\": \"{{server.build.env.STEAM_LOGIN_TOKEN}}\",\r\n            \"AdminSteamID\": \"{{server.build.env.STEAM_ADMIN_ID}}\"\r\n        }\r\n    }\r\n}",
-        "startup": "{\r\n    \"done\": \"Match State Changed from EnteringMap to WaitingToStart\",\r\n    \"userInteraction\": []\r\n}",
-        "logs": "{\r\n    \"custom\": true,\r\n    \"location\": \"logs\/latest.log\"\r\n}",
+        "startup": "{\r\n    \"done\": \"Match State Changed from EnteringMap to WaitingToStart\"\r\n}",
+        "logs": "{}",
         "stop": "^C"
     },
     "scripts": {
@@ -28,8 +35,8 @@
             "description": "Login and generate a token for the app-id: 394690\r\nhttps:\/\/steamcommunity.com\/dev\/managegameservers",
             "env_variable": "STEAM_LOGIN_TOKEN",
             "default_value": "",
-            "user_viewable": 1,
-            "user_editable": 1,
+            "user_viewable": true,
+            "user_editable": true,
             "rules": "required|string|max:100"
         },
         {
@@ -37,8 +44,8 @@
             "description": "Note that your admin id is only a number!",
             "env_variable": "STEAM_ADMIN_ID",
             "default_value": "",
-            "user_viewable": 1,
-            "user_editable": 1,
+            "user_viewable": true,
+            "user_editable": true,
             "rules": "required|integer|max:76561202255233023"
         },
         {
@@ -46,8 +53,8 @@
             "description": "",
             "env_variable": "SERVER_TITLE",
             "default_value": "Tower Unite Server",
-            "user_viewable": 1,
-            "user_editable": 1,
+            "user_viewable": true,
+            "user_editable": true,
             "rules": "required|string|max:512"
         },
         {
@@ -55,8 +62,8 @@
             "description": "",
             "env_variable": "SERVER_MAX_PLAYER",
             "default_value": "40",
-            "user_viewable": 0,
-            "user_editable": 0,
+            "user_viewable": false,
+            "user_editable": false,
             "rules": "required|integer|max:512"
         }
     ]

--- a/game_eggs/steamcmd_servers/unturned/egg-unturned.json
+++ b/game_eggs/steamcmd_servers/unturned/egg-unturned.json
@@ -1,18 +1,25 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
-        "version": "PTDL_v1"
+        "version": "PTDL_v1",
+        "update_url": null
     },
-    "exported_at": "2020-07-12T22:04:47-04:00",
+    "exported_at": "2022-01-20T13:04:52-05:00",
     "name": "Unturned",
     "author": "parker@parkervcp.com",
     "description": "Vanilla Unturned with the included RockerMod.",
-    "image": "quay.io\/parkervcp\/pterodactyl-images:debian_source",
+    "features": [
+        "steam_disk_space"
+    ],
+    "images": [
+        "quay.io\/parkervcp\/pterodactyl-images:debian_source"
+    ],
+    "file_denylist": [],
     "startup": ".\/Unturned_Headless.x86_64 -batchmode -nographics -bind 0.0.0.0 -port {{SERVER_PORT}}",
     "config": {
         "files": "{}",
-        "startup": "{\r\n    \"done\": \"Loading level: 100%\",\r\n    \"userInteraction\": []\r\n}",
-        "logs": "{\r\n    \"custom\": true,\r\n    \"location\": \"latest.log\"\r\n}",
+        "startup": "{\r\n    \"done\": \"Loading level: 100%\"\r\n}",
+        "logs": "{}",
         "stop": "shutdown"
     },
     "scripts": {
@@ -28,8 +35,8 @@
             "description": "Steam App ID require for install and startup update",
             "env_variable": "SRCDS_APPID",
             "default_value": "1110390",
-            "user_viewable": 0,
-            "user_editable": 0,
+            "user_viewable": false,
+            "user_editable": false,
             "rules": "required|string|max:20"
         },
         {
@@ -37,8 +44,8 @@
             "description": "This is needed to load specific libraries",
             "env_variable": "LD_LIBRARY_PATH",
             "default_value": ".\/Unturned_Headless_Data\/Plugins\/x86_64\/",
-            "user_viewable": 0,
-            "user_editable": 0,
+            "user_viewable": false,
+            "user_editable": false,
             "rules": "required|string"
         },
         {
@@ -46,8 +53,8 @@
             "description": "Should be left blank for anon user",
             "env_variable": "STEAM_USER",
             "default_value": "",
-            "user_viewable": 1,
-            "user_editable": 1,
+            "user_viewable": true,
+            "user_editable": true,
             "rules": "nullable|string"
         },
         {
@@ -55,8 +62,8 @@
             "description": "",
             "env_variable": "STEAM_PASS",
             "default_value": "",
-            "user_viewable": 1,
-            "user_editable": 1,
+            "user_viewable": true,
+            "user_editable": true,
             "rules": "nullable|string"
         }
     ]

--- a/game_eggs/steamcmd_servers/valheim/valheim_plus/egg-valheim-plus-mod.json
+++ b/game_eggs/steamcmd_servers/valheim/valheim_plus/egg-valheim-plus-mod.json
@@ -8,7 +8,9 @@
     "name": "Valheim Plus Mod",
     "author": "info@goover.de",
     "description": "A brutal exploration and survival game for 1-10 players, set in a procedurally-generated purgatory inspired by viking culture.",
-    "features": null,
+    "features": [
+        "steam_disk_space"
+    ],
     "images": [
         "quay.io\/parkervcp\/pterodactyl-images:debian_source"
     ],

--- a/game_eggs/steamcmd_servers/valheim/valheim_vanilla/egg-valheim.json
+++ b/game_eggs/steamcmd_servers/valheim/valheim_vanilla/egg-valheim.json
@@ -8,7 +8,9 @@
     "name": "Valheim",
     "author": "magi1053@outlook.com",
     "description": "A brutal exploration and survival game for 1-10 players, set in a procedurally-generated purgatory inspired by viking culture.",
-    "features": null,
+    "features": [
+        "steam_disk_space"
+    ],
     "images": [
         "quay.io\/parkervcp\/pterodactyl-images:debian_source"
     ],


### PR DESCRIPTION
A new egg feature modal was introduced in Panel v1.7.0 triggering when a server has run out of disk space to provide more user-friendly instructions to both admins and normal users. This is unique to SteamCMD specific errors.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

### Changes to an existing Egg:

1. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [x] Have you tested your Egg changes?
