### PR TITLE
[JMusicBot] Changed docker image to use java 16 - music playback doesn't work with java 8

### DIFF
--- a/bots/discord/jmusicbot/egg-j-music-bot.json
+++ b/bots/discord/jmusicbot/egg-j-music-bot.json
@@ -9,7 +9,7 @@
     "description": "A Discord music bot that's easy to set up and run yourself!",
     "features": null,
     "images": [
-        "ghcr.io\/parkervcp\/yolks:java_8"
+        "ghcr.io\/pterodactyl\/yolks:java_16"
     ],
     "file_denylist": [],
     "startup": "java -Dnogui=true -jar JMusicBot.jar",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

### Changes to an existing Egg:

JMusicBot could not play any music while using java 8. By switching to java 16 it works as intended.

1. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [x] Have you tested your Egg changes? - Yes, currently running on a discord server.

Edit: Typo
