### PR TITLE
egg-insurgency--sandstorm.json: fix "Max Players"

### DIFF
--- a/game_eggs/steamcmd_servers/insurgency_sandstorm/egg-insurgency--sandstorm.json
+++ b/game_eggs/steamcmd_servers/insurgency_sandstorm/egg-insurgency--sandstorm.json
@@ -60,7 +60,7 @@
         {
             "name": "Max Players",
             "description": "Sets the maximum number of players.",
-            "env_variable": "MAXPLAYERS",
+            "env_variable": "MAX_PLAYERS",
             "default_value": "28",
             "user_viewable": true,
             "user_editable": true,


### PR DESCRIPTION
"Max Players" var was defined as MAXPLAYERS, but referred as MAX_PLAYERS. Changed the definition instead of the startup command to keep it consistent with other steam games.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Did you branch your changes and PR from that branch and not from your master branch?

### Changes to an existing Egg:

1. [X] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [X] Have you tested your Egg changes?
