### PR TITLE
feat(arma 3): Variable for specifying optional mods

### DIFF
--- a/game_eggs/steamcmd_servers/arma/arma3/egg-arma3.json
+++ b/game_eggs/steamcmd_servers/arma/arma3/egg-arma3.json
@@ -139,6 +139,15 @@
             "rules": "nullable|string"
         },
         {
+            "name": "Optional Mods",
+            "description": "A semicolon-separated list of optional mod folders to load into the keys folder, but not include in server's mod parameter. Useful for allowing clients to connect to the server with or without the mod loaded. Any mods in this list that are in \"@workshopID\" form will also be included in Automatic Updates (if enabled). NO capital letters, spaces, or folders starting with a number! (ex. myMod;vn;@123456789;@987654321;etc;)",
+            "env_variable": "OPTIONALMODS",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "nullable|string"
+        },
+        {
             "name": "[Repair] Make Mod Files Lowercase",
             "description": "Every mod that is set to be loaded will have its folder and files changed to lowercase (to prevent errors). It is recommended to enable this for one server boot after copying a mod from a Windows machine to the server, or if mods seem to not be loading. (1 Enable | 0 Disable)",
             "env_variable": "MODS_LOWERCASE",

--- a/game_eggs/steamcmd_servers/arma/arma3/egg-arma3.json
+++ b/game_eggs/steamcmd_servers/arma/arma3/egg-arma3.json
@@ -139,15 +139,6 @@
             "rules": "nullable|string"
         },
         {
-            "name": "Optional Mods",
-            "description": "A semicolon-separated list of optional mod folders to load into the keys folder, but not include in server's mod parameter. Useful for allowing clients to connect to the server with or without the mod loaded. Any mods in this list that are in \"@workshopID\" form will also be included in Automatic Updates (if enabled). NO capital letters, spaces, or folders starting with a number! (ex. myMod;vn;@123456789;@987654321;etc;)",
-            "env_variable": "OPTIONALMODS",
-            "default_value": "",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": "nullable|string"
-        },
-        {
             "name": "[Repair] Make Mod Files Lowercase",
             "description": "Every mod that is set to be loaded will have its folder and files changed to lowercase (to prevent errors). It is recommended to enable this for one server boot after copying a mod from a Windows machine to the server, or if mods seem to not be loading. (1 Enable | 0 Disable)",
             "env_variable": "MODS_LOWERCASE",
@@ -169,6 +160,15 @@
             "name": "[Advanced] Server-Side Only Mods",
             "description": "Mod folders to be used with the \"-serverMods\" startup option. They only run server-side and are not required by clients if \"verifySignatures\" is enabled. Any mods in this list that are in \"@workshopID\" form will also be included in Automatic Updates (if enabled). NO capital letters, spaces, or folders starting with a number! Each folder must be followed with a semicolon (ex. @123456789;@987654321;etc;)",
             "env_variable": "SERVERMODS",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "nullable|string"
+        },
+        {
+            "name": "[Advanced] Optional Client-Side Mods",
+            "description": "A semicolon-separated list of optional mods to load into the keys folder, but not include in server's mod parameter. Useful for allowing clients to connect to the server with or without the mod loaded. Mods in this list must be in \"@workshopID\" form (ex. @123456789;@987654321;). These will also be included in Automatic Updates (if enabled).",
+            "env_variable": "OPTIONALMODS",
             "default_value": "",
             "user_viewable": true,
             "user_editable": true,


### PR DESCRIPTION
Adds the ability to specify optional mods to be downloaded and configured on the server. Optional mods are mods that aren't required by clients joining the server, but clients are permitted to join with them. This works by having the mods .bikey files installed in the keys directory.

Linked PR in the yolks repo: https://github.com/parkervcp/yolks/pull/49

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Did you branch your changes and PR from that branch and not from your master branch?

### Changes to an existing Egg:

1. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [x] Have you tested your Egg changes?
