### PR TITLE
[Satisfactory] Add "Disable Seasonal Events" Startup Parameter

### DIFF
--- a/game_eggs/steamcmd_servers/satisfactory/README.md
+++ b/game_eggs/steamcmd_servers/satisfactory/README.md
@@ -1,7 +1,10 @@
 # Satisfactory
+
 ***Updating your Egg?**: Ensure any existing servers have the latest Startup Command, new Startup Variables are set, **and you reinstall server!***
 ___
+
 ### Authors / Contributors
+
 <!-- prettier-ignore-start -->
 <!-- markdownlint-disable -->
 <table>
@@ -59,11 +62,16 @@ ___
 <!-- prettier-ignore-end -->
 
 ___
+
 ### Game Description
+
 From Coffee Stain's [Website](https://www.satisfactorygame.com/):
 > Satisfactory is a first-person open-world factory building game with a dash of exploration and combat. Play alone or with friends, explore an alien planet, create multi-story factories, and enter conveyor belt heaven!
+
 ___
+
 ### Egg Capabilities
+
 - Configuration of the Server Query, Beacon, and Game ports.
 - Configurable to automatically check for server updates on start via SteamCMD. Forcing validation is also configurable.
 - *[Experimental]* Max player configuration.
@@ -71,8 +79,11 @@ ___
 - Disable crash reporting if desired.
 - Disable seasonal events if desired.
 - ...and other advanced networking and server branch configurable settings.
+
 ___
+
 ### Server Ports
+
 - Default server ports are listed below, but all three ports can be changed freely (\*some exceptions apply below).
     - All three ports must be unique; they cannot currently be shared on one port (this may change in the future).
     - It is recommended to distance ports of other running Satisfactory servers in Pterodactyl by **increments of 100** (it is currently unknown what the minimum increment is, but an increment of +1 caused cross-server talk in testing). Also, your internal ports **must match** your external ports on your network (ie. you can't have an external port of 7778 forwarded to your 7777 internal port; they must match).
@@ -86,6 +97,7 @@ ___
 | Server Query (Port clients connect with) | 15777 |
 
 ___
+
 ### Installation/System Requirements
 
 |  | Bare Minimum | Recommended |
@@ -98,40 +110,56 @@ ___
 | Game Ownership | Not required to start. | Required to fully "initialize" (see [Server Initialization](#server-initialization) below) |
 
 ___
+
 ### Server Initialization
+
 For a server to be fully "initialized", a client who owns the game must log into the server to "claim" it and create an administrator password. Then, a new session can be created via the "Create Game" tab in-game, or an existing save file can be uploaded (see [Save Files](#save-files) below).
 
 Misc. settings listed below can be configured by an admin client via the game's "Server Settings" tab, and are currently **not** set via the Egg:
+
 - Server Password
 - Admin Password
 - Auto-Save on Player Disconnect
 - Pause When No Players Online
 - ...and possibly more as the client's UI is developed further for more configuration options.
+
 ___
+
 ### Save Files
+
 An existing save file (including single-player saves) can currently be uploaded to the server via two different methods:
+
 - "Manage Saves" tab via an admin client in-game (Recommended)
 - Manually via the File Manager or SFTP
 
 Save files are located in this directory:
+
 ```md
 /home/container/.config/Epic/FactoryGame/Saved/SaveGames/server
 ```
+
 *Note: A manually uploaded save will only load if it is (a.) loaded manually via the "Manage Saves" tab in-game, (b.) it is the only save file present, or (c.) its existing session name (not its file name) matches the existing save's session name *and* has the most recent time stamp.*
 
 ***Warning:*** Stopping the server **does not** currently save your game! Ensure it is saved before stopping the server.
 
 If you have forgotten your administrator password or would generally like to reset your server as if it were new, you can delete the following file:
+
 ```md
 /home/container/.config/Epic/FactoryGame/Saved/SaveGames/ServerSettings.<your_server_query_port>
 ```
+
 ___
+
 ### Console Commands
+
 As of v0.5.1.10, the console tab in the client server manager is the only way to execute commands. Entering commands via Pterodactyl do nothing.
 
 [List of known commands can be found via the Wiki.](https://satisfactory.fandom.com/wiki/Dedicated_servers#Console_commands)
+
 ___
+
 ### Known Errors/Warnings
+
 The following errors or warnings you see in the console can safely be ignored:
 
 ```log
@@ -139,6 +167,7 @@ steamclient.so: cannot open shared object file: No such file or directory
 [S_API] SteamAPI_Init(): Loaded '/home/container/.steam/sdk64/steamclient.so' OK.  (First tried local 'steamclient.so')
 LogSteamShared: Warning: Steam Dedicated Server API failed to initialize.
 ```
+
 ↑ The local file of 'steamclient.so' was attempted to be loaded, but could not because it is not present, causing the warning message. However, the backup `/home/container/.steam/sdk64/steamclient.so` is loaded successfully (this is the correct behavior according to the [Wiki](https://satisfactory.fandom.com/wiki/Dedicated_servers#SteamAPI_Init.28.29:_Sys_LoadModule_filed_to_load:_.2Fpath.2Fto.2F.steam.2Fsdk64.2Fsteamclient.so)).
 
 ```log
@@ -150,13 +179,17 @@ Warning: failed to init SDL thread priority manager: SDL not found
 ```log
 ...Error: Couldn't find file for package...
 ```
+
 ```log
 ...Error: Navmesh bounds are too large!...
 ```
+
 ```log
 ...Warning: NiagaraSystem...
 ```
+
 ```log
 LogStreaming: Warning: Failed to read file '../../../FactoryGame/Saved/SaveGames/GameAnalytics.sav' error.
 ```
+
 ↑ These seem to be common error messages with the current experimental version of the game.

--- a/game_eggs/steamcmd_servers/satisfactory/README.md
+++ b/game_eggs/steamcmd_servers/satisfactory/README.md
@@ -1,10 +1,7 @@
 # Satisfactory
-
 ***Updating your Egg?**: Ensure any existing servers have the latest Startup Command, new Startup Variables are set, **and you reinstall server!***
 ___
-
-## Authors / Contributors
-
+### Authors / Contributors
 <!-- prettier-ignore-start -->
 <!-- markdownlint-disable -->
 <table>
@@ -62,40 +59,33 @@ ___
 <!-- prettier-ignore-end -->
 
 ___
-
 ### Game Description
-
 From Coffee Stain's [Website](https://www.satisfactorygame.com/):
 > Satisfactory is a first-person open-world factory building game with a dash of exploration and combat. Play alone or with friends, explore an alien planet, create multi-story factories, and enter conveyor belt heaven!
-
 ___
-
 ### Egg Capabilities
-
 - Configuration of the Server Query, Beacon, and Game ports.
 - Configurable to automatically check for server updates on start via SteamCMD. Forcing validation is also configurable.
 - *[Experimental]* Max player configuration.
 - Autosave amount and interval configuration.
 - Disable crash reporting if desired.
+- Disable seasonal events if desired.
 - ...and other advanced networking and server branch configurable settings.
-
 ___
-
 ### Server Ports
-
-- Default server ports are listed below, but all three ports can be changed freely.
+- Default server ports are listed below, but all three ports can be changed freely (\*some exceptions apply below).
+    - All three ports must be unique; they cannot currently be shared on one port (this may change in the future).
+    - It is recommended to distance ports of other running Satisfactory servers in Pterodactyl by **increments of 100** (it is currently unknown what the minimum increment is, but an increment of +1 caused cross-server talk in testing). Also, your internal ports **must match** your external ports on your network (ie. you can't have an external port of 7778 forwarded to your 7777 internal port; they must match).
 - **Note:** The Primary/Default/Game Port for your server in Pterodactyl will be Satisfactory's `-Port=????` game port, even though clients will **connect with the Query port**.
-- It is recommended to distance ports of other running Satisfactory servers in Pterodactyl by **increments of 100** (it is currently unknown what the minimum increment is, but an increment of +1 caused cross-server talk in testing). Also, your internal ports **must match** your external ports on your network (ie. you can't have an external port of 7778 forwarded to your 7777 internal port; they must match).
 - ***All three ports are required to be open/allocated for normal server behavior!***
 
 | Port | Default (UDP) |
 |---------|---------|
 | **Game (Primary Port in Pterodactyl)** | 7777 |
 | Beacon | 15000 |
-| Server Query | 15777 |
+| Server Query (Port clients connect with) | 15777 |
 
 ___
-
 ### Installation/System Requirements
 
 |  | Bare Minimum | Recommended |
@@ -108,54 +98,40 @@ ___
 | Game Ownership | Not required to start. | Required to fully "initialize" (see [Server Initialization](#server-initialization) below) |
 
 ___
-
 ### Server Initialization
-
 For a server to be fully "initialized", a client who owns the game must log into the server to "claim" it and create an administrator password. Then, a new session can be created via the "Create Game" tab in-game, or an existing save file can be uploaded (see [Save Files](#save-files) below).
 
 Misc. settings listed below can be configured by an admin client via the game's "Server Settings" tab, and are currently **not** set via the Egg:
-
 - Server Password
 - Admin Password
 - Auto-Save on Player Disconnect
 - Pause When No Players Online
 - ...and possibly more as the client's UI is developed further for more configuration options.
-
 ___
-
 ### Save Files
-
 An existing save file (including single-player saves) can currently be uploaded to the server via two different methods:
-- "Manage Saves" tab via a client in-game (Recommended)
+- "Manage Saves" tab via an admin client in-game (Recommended)
 - Manually via the File Manager or SFTP
 
 Save files are located in this directory:
-
 ```md
 /home/container/.config/Epic/FactoryGame/Saved/SaveGames/server
 ```
-
 *Note: A manually uploaded save will only load if it is (a.) loaded manually via the "Manage Saves" tab in-game, (b.) it is the only save file present, or (c.) its existing session name (not its file name) matches the existing save's session name *and* has the most recent time stamp.*
 
 ***Warning:*** Stopping the server **does not** currently save your game! Ensure it is saved before stopping the server.
 
 If you have forgotten your administrator password or would generally like to reset your server as if it were new, you can delete the following file:
-
 ```md
 /home/container/.config/Epic/FactoryGame/Saved/SaveGames/ServerSettings.<your_server_query_port>
 ```
-
 ___
-
 ### Console Commands
-
-As of v0.5.1.2, the console tab in the client server manager is the only way to execute commands. Entering commands via Pterodactyl do nothing.
+As of v0.5.1.10, the console tab in the client server manager is the only way to execute commands. Entering commands via Pterodactyl do nothing.
 
 [List of known commands can be found via the Wiki.](https://satisfactory.fandom.com/wiki/Dedicated_servers#Console_commands)
 ___
-
-### Errors/Warnings
-
+### Known Errors/Warnings
 The following errors or warnings you see in the console can safely be ignored:
 
 ```log
@@ -163,29 +139,24 @@ steamclient.so: cannot open shared object file: No such file or directory
 [S_API] SteamAPI_Init(): Loaded '/home/container/.steam/sdk64/steamclient.so' OK.  (First tried local 'steamclient.so')
 LogSteamShared: Warning: Steam Dedicated Server API failed to initialize.
 ```
-
-The local file of 'steamclient.so' was attempted to be loaded, but could not because it is not present, causing the warning message. However, the backup `/home/container/.steam/sdk64/steamclient.so` is loaded successfully (this is the correct behavior according to the [Wiki](https://satisfactory.fandom.com/wiki/Dedicated_servers#SteamAPI_Init.28.29:_Sys_LoadModule_filed_to_load:_.2Fpath.2Fto.2F.steam.2Fsdk64.2Fsteamclient.so)).
+↑ The local file of 'steamclient.so' was attempted to be loaded, but could not because it is not present, causing the warning message. However, the backup `/home/container/.steam/sdk64/steamclient.so` is loaded successfully (this is the correct behavior according to the [Wiki](https://satisfactory.fandom.com/wiki/Dedicated_servers#SteamAPI_Init.28.29:_Sys_LoadModule_filed_to_load:_.2Fpath.2Fto.2F.steam.2Fsdk64.2Fsteamclient.so)).
 
 ```log
 Warning: failed to init SDL thread priority manager: SDL not found
 ```
 
-This is a common error with Steam related software on Linux, but can safely be ignored.
+↑ This is a common error with Steam related software on Linux, but can safely be ignored.
 
 ```log
 ...Error: Couldn't find file for package...
 ```
-
 ```log
 ...Error: Navmesh bounds are too large!...
 ```
-
 ```log
 ...Warning: NiagaraSystem...
 ```
-
 ```log
 LogStreaming: Warning: Failed to read file '../../../FactoryGame/Saved/SaveGames/GameAnalytics.sav' error.
 ```
-
-These seem to be common error messages with the current experimental version of the game.
+↑ These seem to be common error messages with the current experimental version of the game.

--- a/game_eggs/steamcmd_servers/satisfactory/egg-satisfactory.json
+++ b/game_eggs/steamcmd_servers/satisfactory/egg-satisfactory.json
@@ -1,5 +1,5 @@
 {
-    "_comment": "Pterodactyl Satisfactory Egg ~ Red-Thirten, Kubi, matthewp, Software-Noob, and Zarklord ~ 2021-11-29",
+    "_comment": "Pterodactyl Satisfactory Egg ~ Red-Thirten, Kubi, matthewp, Software-Noob, and Zarklord ~ 2022-02-07",
     "meta": {
         "version": "PTDL_v1",
         "update_url": null
@@ -14,7 +14,7 @@
         "ghcr.io\/parkervcp\/games:source"
     ],
     "file_denylist": [],
-    "startup": ".\/Engine\/Binaries\/Linux\/UE4Server-Linux-Shipping FactoryGame ?listen -Port={{SERVER_PORT}} -ServerQueryPort={{QUERY_PORT}} -BeaconPort={{BEACON_PORT}} -multihome=0.0.0.0",
+    "startup": ".\/Engine\/Binaries\/Linux\/UE4Server-Linux-Shipping FactoryGame ?listen -Port={{SERVER_PORT}} -ServerQueryPort={{QUERY_PORT}} -BeaconPort={{BEACON_PORT}} -multihome=0.0.0.0 $(if {{DISABLE_SEASONAL}}; then echo \"-DisableSeasonalEvents\"; fi)",
     "config": {
         "files": "{\r\n    \"FactoryGame\/Saved\/Config\/LinuxServer\/Game.ini\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"MaxPlayers\": \"MaxPlayers={{server.build.env.MAX_PLAYERS}}\"\r\n        }\r\n    },\r\n    \"FactoryGame\/Saved\/Config\/LinuxServer\/Engine.ini\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"mNumRotatingAutosaves\": \"mNumRotatingAutosaves={{server.build.env.NUM_AUTOSAVES}}\",\r\n            \"bImplicitSend\": \"bImplicitSend={{server.build.env.UPLOAD_CRASH_REPORT}}\",\r\n            \"InitialConnectTimeout\": \"InitialConnectTimeout={{server.build.env.INIT_CONNECT_TIMEOUT}}\",\r\n            \"ConnectionTimeout\": \"ConnectionTimeout={{server.build.env.CONNECT_TIMEOUT}}\"\r\n        }\r\n    },\r\n    \"FactoryGame\/Saved\/Config\/LinuxServer\/GameUserSettings.ini\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"mFloatValues\": \"mFloatValues=((\\\"FG.AutosaveInterval\\\", {{server.build.env.AUTOSAVE_INTERVAL}}))\",\r\n            \"mIntValues\": \"mIntValues=((\\\"FG.NetworkQuality\\\", {{server.build.env.NETWORK_QUALITY}}))\"\r\n        }\r\n    }\r\n}",
         "startup": "{\r\n    \"done\": \"Engine Initialization\"\r\n}",
@@ -88,6 +88,15 @@
             "description": "Accepted values are \"true\" or \"false\". Determines if the server should upload any crash reports to the developer to help pinpoint issues for future patches.",
             "env_variable": "UPLOAD_CRASH_REPORT",
             "default_value": "true",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string|in:true,false"
+        },
+        {
+            "name": "Disable Seasonal Events",
+            "description": "Accepted values are \"true\" or \"false\". Setting to \"true\" will disable any currently active seasonal events.",
+            "env_variable": "DISABLE_SEASONAL",
+            "default_value": "false",
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|string|in:true,false"


### PR DESCRIPTION
Egg has been updated to the support the new `-DisableSeasonalEvents` startup flag (that was apparently [added in 0.5.1.4](https://satisfactory.fandom.com/wiki/Patch_0.5.1.4), but isn't listed on their dedicated server wiki page), via a Startup Parameter.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
   * Similar (but not identical) PR #1489 is open, but appears to be abandoned after the author welcomed my contributions to be PR'ed to his fork (which I did), but they never replied or merged. Therefore this PR serves as a replacement.
* [x] Did you branch your changes and PR from that branch and not from your master branch?

### Changes to an existing Egg:

1. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [x] Have you tested your Egg changes?
