### PR TITLE
Fix download link for Flamecord

### DIFF
--- a/game_eggs/minecraft/proxy/java/flamecord/egg-flamecord.json
+++ b/game_eggs/minecraft/proxy/java/flamecord/egg-flamecord.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v1",
         "update_url": null
     },
-    "exported_at": "2021-12-09T13:32:08-05:00",
+    "exported_at": "2022-05-06T10:20:32+02:00",
     "name": "Flamecord",
     "author": "admin@softwarenoob.com",
     "description": "FlameCord is a patch for Travertine to fix possible exploits and add useful functionalities. FlameCord aims to fix Netty related exploits to keep your server safe from attacks.",
@@ -23,13 +23,13 @@
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",
     "config": {
         "files": "{\r\n    \"config.yml\": {\r\n        \"parser\": \"yaml\",\r\n        \"find\": {\r\n            \"listeners[0].host\": \"0.0.0.0:{{server.build.default.port}}\",\r\n            \"servers.*.address\": {\r\n                \"127.0.0.1\": \"{{config.docker.interface}}\",\r\n                \"localhost\": \"{{config.docker.interface}}\"\r\n            }\r\n        }\r\n    }\r\n}",
-        "startup": "{\r\n    \"done\": \"Listening on \",\r\n    \"userInteraction\": [\r\n        \"Listening on \/0.0.0.0:\"\r\n    ]\r\n}",
+        "startup": "{\r\n    \"done\": \"Listening on \"\r\n}",
         "logs": "{}",
         "stop": "end"
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/bash\r\n# Travertine Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\nMATCH=Flamecord.jar\r\napt update\r\napt install -y curl jq\r\n\r\n\r\n## get release info and download links\r\nLATEST_JSON=$(curl --silent \"https:\/\/api.github.com\/repos\/2lstudios-mc\/FlameCord\/releases\/latest\")\r\nRELEASES=$(curl --silent \"https:\/\/api.github.com\/repos\/2lstudios-mc\/FlameCord\/releases\")\r\n\r\nif [ -z \"${VERSION}\" ] || [ \"${VERSION}\" == \"latest\" ]; then\r\n    echo \"Downloading latest version\"\r\n    DOWNLOAD_URL=$(echo ${LATEST_JSON} | jq .assets | jq -r .[].browser_download_url | grep -i ${MATCH})\r\nelse\r\n    VERSION_CHECK=$(echo ${RELEASES} | jq -r --arg VERSION \"${VERSION}\" '.[] | select(.tag_name==$VERSION) | .tag_name')\r\n    if [ \"${VERSION}\" == \"${VERSION_CHECK}\" ]; then\r\n        DOWNLOAD_URL=$(echo ${RELEASES} | jq -r --arg VERSION \"${VERSION}\" '.[] | select(.tag_name==$VERSION) | .assets[].browser_download_url' | grep -i ${MATCH})\r\n        echo \"Download version ${VERSION}\"\r\n    else\r\n        echo -e \"defaulting to latest release\"\r\n        DOWNLOAD_URL=$(echo ${LATEST_JSON} | jq .assets | jq -r .[].browser_download_url)\r\n    fi\r\nfi\r\n\r\ncd \/mnt\/server\r\n\r\necho -e \"curl -L ${DOWNLOAD_URL} -o ${SERVER_JARFILE}\"\r\n\r\nif [ -f ${SERVER_JARFILE} ]; then\r\n\tmv ${SERVER_JARFILE} ${SERVER_JARFILE}.old\r\nfi\r\n\r\ncurl -L ${DOWNLOAD_URL} -o ${SERVER_JARFILE}\r\necho \"Install complete\"",
+            "script": "#!\/bin\/bash\r\n# FlameCord Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\napt update\r\napt install -y curl\r\n\r\n# Get download link\r\nif [ -z \"${FLAMECORD_VERSION}\" ] || [ \"${FLAMECORD_VERSION}\" == \"latest\" ]; then\r\n    echo -e \"Downloading latest FlameCord build\"\r\n    DOWNLOAD_URL=https:\/\/ci.2lstudios.dev\/job\/FlameCord\/lastSuccessfulBuild\/artifact\/FlameCord-Proxy\/bootstrap\/target\/FlameCord.jar\r\nelse \r\n    echo -e \"Downloading FlameCord build ${FLAMECORD_VERSION}\"\r\n    DOWNLOAD_URL=https:\/\/ci.2lstudios.dev\/job\/FlameCord\/${FLAMECORD_VERSION}\/artifact\/FlameCord-Proxy\/bootstrap\/target\/FlameCord.jar\r\nfi\r\n\r\ncd \/mnt\/server\r\n\r\necho -e \"curl -L ${DOWNLOAD_URL} -o ${SERVER_JARFILE}\"\r\n\r\nif [ -f ${SERVER_JARFILE} ]; then\r\n\tmv ${SERVER_JARFILE} ${SERVER_JARFILE}.old\r\nfi\r\n\r\ncurl -L ${DOWNLOAD_URL} -o ${SERVER_JARFILE}\r\necho \"Install complete\"",
             "container": "debian:buster-slim",
             "entrypoint": "bash"
         }
@@ -37,7 +37,7 @@
     "variables": [
         {
             "name": "Flamecord Version",
-            "description": "The Github release version of Flamecord to install such as 48d53ee, all releases at https:\/\/github.com\/2lstudios-mc\/FlameCord\/releases",
+            "description": "The build to pull and install. (Ex. 97), or set to latest.\r\n\r\nYou can find all builds on https:\/\/ci.2lstudios.dev\/job\/FlameCord\/",
             "env_variable": "FLAMECORD_VERSION",
             "default_value": "latest",
             "user_viewable": true,


### PR DESCRIPTION
Flamecord switched from Github Releases to [Jenkins](https://ci.2lstudios.dev/job/FlameCord/). This updates the download to match that.

Fixes #1621

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Did you branch your changes and PR from that branch and not from your master branch?

### Changes to an existing Egg:

1. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [x] Have you tested your Egg changes?
