### PR TITLE
Update Among Us - Impostor

### DIFF
--- a/game_eggs/among_us/impostor_server/egg-among-us--impostor-server.json
+++ b/game_eggs/among_us/impostor_server/egg-among-us--impostor-server.json
@@ -7,7 +7,7 @@
     "exported_at": "2021-07-23T12:00:05+03:00",
     "name": "Among Us - Impostor Server",
     "author": "info@goover.de",
-    "description": "Impostor is one of the first Among Us private servers, written in C#.\r\n\r\nThe latest version supported is 2020.9.22, both desktop and mobile.\r\n\r\nThere are no special features at this moment, the goal is aiming to be as close as possible to the real server, for now. In a later stage, making modifications to game logic by modifying GameData packets can be looked at.",
+    "description": "Impostor is one of the first Among Us private servers, written in C#.\r\n\r\nThe latest version supported is 2022.4.19, both desktop and mobile.\r\n\r\nThere are no special features at this moment, the goal is aiming to be as close as possible to the real server, for now. In a later stage, making modifications to game logic by modifying GameData packets can be looked at.",
     "features": null,
     "images": [
         "qaeonlucid/impostor:nightly"

--- a/game_eggs/among_us/impostor_server/egg-among-us--impostor-server.json
+++ b/game_eggs/among_us/impostor_server/egg-among-us--impostor-server.json
@@ -10,7 +10,7 @@
     "description": "Impostor is one of the first Among Us private servers, written in C#.\r\n\r\nThe latest version supported is 2020.9.22, both desktop and mobile.\r\n\r\nThere are no special features at this moment, the goal is aiming to be as close as possible to the real server, for now. In a later stage, making modifications to game logic by modifying GameData packets can be looked at.",
     "features": null,
     "images": [
-        "quay.io\/parkervcp\/pterodactyl-images:debian_dotnet-5"
+        "qaeonlucid/impostor:nightly"
     ],
     "file_denylist": [],
     "startup": ".\/Impostor.Server",

--- a/game_eggs/among_us/impostor_server/egg-among-us--impostor-server.json
+++ b/game_eggs/among_us/impostor_server/egg-among-us--impostor-server.json
@@ -10,7 +10,7 @@
     "description": "Impostor is one of the first Among Us private servers, written in C#.\r\n\r\nThe latest version supported is 2022.4.19, both desktop and mobile.\r\n\r\nThere are no special features at this moment, the goal is aiming to be as close as possible to the real server, for now. In a later stage, making modifications to game logic by modifying GameData packets can be looked at.",
     "features": null,
     "images": [
-        "qaeonlucid/impostor:nightly"
+        "ghcr.io/parkervcp/yolks:dotnet_6"
     ],
     "file_denylist": [],
     "startup": ".\/Impostor.Server",


### PR DESCRIPTION
The .NET Image used here is out of date and it requires .NET 6 to run. They have their own image so I have instead switched the image to that and the issue has been resolved.

> I'd rather you update the image versus updating the egg to use your image. #1261

I am not sure how you want us to update the image if this is hosted on your side and when I tried to use the following image it does not exist -```quay.io\/parkervcp\/pterodactyl-images:debian_dotnet-6```
Whereas the image I have provided, like the one in the previously mentioned PR, is the one provided by the developers of Impostor. This can be found here and using this image does not lead to any issues - https://github.com/Impostor/Impostor/blob/master/docs/Running-the-server.md#using-docker-compose

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Did you branch your changes and PR from that branch and not from your master branch?

### Changes to an existing Egg:

1. [X] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [X] Have you tested your Egg changes?
