### PR TITLE
Update egg-loki.json

### DIFF
--- a/monitoring/loki/egg-loki.json
+++ b/monitoring/loki/egg-loki.json
@@ -4,16 +4,16 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2022-07-03T17:40:29-04:00",
+    "exported_at": "2022-07-08T15:50:16+02:00",
     "name": "Loki",
     "author": "unknown@unknown.com",
     "description": "Prometheus but for logs. This egg is for Loki instance only! You usually need pushing agents like Promtail to put logs in this",
     "features": null,
     "docker_images": {
-        "ghcr.io\/pterodactyl\/yolks:debian": "ghcr.io\/pterodactyl\/yolks:debian"
+        "ghcr.io\/parkervcp\/yolks:debian": "ghcr.io\/parkervcp\/yolks:debian"
     },
     "file_denylist": [],
-    "startup": ".\/loki-linux-amd64 -config.file=loki-docker-config.yaml",
+    "startup": ".\/loki-linux -config.file=loki-docker-config.yaml",
     "config": {
         "files": "{\r\n    \"loki-docker-config.yaml\": {\r\n        \"parser\": \"yaml\",\r\n        \"find\": {\r\n            \"server.http_listen_port\": \"{{server.build.default.port}}\",\r\n            \"common.ring.instance_addr\": \"0.0.0.0\",\r\n            \"common.path_prefix\": \"\/home\/container\/loki\",\r\n            \"common.storage.filesystem.chunks_directory\": \"\/home\/container\/loki\/chunks\",\r\n            \"common.storage.filesystem.rules_directory\": \"\/home\/container\/loki\/rules\"\r\n        }\r\n    }\r\n}",
         "startup": "{\r\n    \"done\": \"Loki started\"\r\n}",
@@ -22,8 +22,8 @@
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/bash\r\n# Switch to mounted working install directory\r\ncd \/mnt\/server\r\n\r\n# Download and extract Loki\r\n\r\nif [ \"$LOKI_VERSION\" = \"latest\" ]; then LOKI_VERSION=$(curl --silent \"https:\/\/api.github.com\/repos\/grafana\/loki\/releases\/latest\" | grep '\"tag_name\":' | sed -E 's\/.*\"([^\"]+)\".*\/\\1\/' | cut -c2-); fi\r\necho -e \"running curl -L https:\/\/github.com\/grafana\/loki\/releases\/download\/v${LOKI_VERSION}\/loki-linux-amd64.zip --output loki-linux-amd64.zip\"\r\ncurl -L https:\/\/github.com\/grafana\/loki\/releases\/download\/v${LOKI_VERSION}\/loki-linux-amd64.zip --output loki-linux-amd64.zip\r\nunzip loki-linux-amd64.zip\r\nrm -rf loki-linux-amd64.zip\r\ncurl -L https:\/\/raw.githubusercontent.com\/grafana\/loki\/v${LOKI_VERSION}\/cmd\/loki\/loki-docker-config.yaml --output loki-docker-config.yaml\r\necho -e \"installation completed\"",
-            "container": "ghcr.io\/parkervcp\/installers:debian",
+            "script": "#!\/bin\/bash\r\n# Switch to mounted working install directory\r\ncd \/mnt\/server\r\n\r\napt update\r\napt install -y zip unzip wget curl git file\r\nARCH=$([[ \"$(uname -m)\" == \"x86_64\" ]] && echo \"amd64\" || echo \"arm64\")\r\n# Download and extract Loki\r\n\r\nif [ \"$LOKI_VERSION\" = \"latest\" ]; then LOKI_VERSION=$(curl --silent \"https:\/\/api.github.com\/repos\/grafana\/loki\/releases\/latest\" | grep '\"tag_name\":' | sed -E 's\/.*\"([^\"]+)\".*\/\\1\/' | cut -c2-); fi\r\necho -e \"running curl -L https:\/\/github.com\/grafana\/loki\/releases\/download\/v${LOKI_VERSION}\/loki-linux-${ARCH}.zip --output loki-linux-amd64.zip\"\r\ncurl -L https:\/\/github.com\/grafana\/loki\/releases\/download\/v${LOKI_VERSION}\/loki-linux-${ARCH}.zip --output loki-linux-${ARCH}.zip\r\nunzip loki-linux-${ARCH}.zip\r\nrm -rf loki-linux-${ARCH}.zip\r\ncurl -L https:\/\/raw.githubusercontent.com\/grafana\/loki\/v${LOKI_VERSION}\/cmd\/loki\/loki-docker-config.yaml --output loki-docker-config.yaml\r\nmv loki-linux-* loki-linux\r\necho -e \"installation completed\"",
+            "container": "ghcr.io\/pterodactyl\/installers:debian",
             "entrypoint": "bash"
         }
     },


### PR DESCRIPTION
Update loki to support arm64

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Did you branch your changes and PR from that branch and not from your master branch?

### Changes to an existing Egg:

1. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
We need to support ARM64 aplication if the build a binary for it
2. [x] Have you tested your Egg changes?
I can confirm it runs on Oracle ARM64

changes: Some images to support ARM64
![afbeelding](https://user-images.githubusercontent.com/67589015/178005488-7b461511-ad34-4a3b-999c-759d3c9a5aee.png)
- change the start command to not be hardcode to AMD64
- add line 7 
- and replace all hardcoded amd64 to ${ARCH}
- move loki-linux-amd64 or loki-linux-arm64 to loki-linux so there is no need for variables in the startup cmd