### PR TITLE
Update egg request issue template with a warning about docker images

### DIFF
--- a/.github/ISSUE_TEMPLATE/egg-request.yml
+++ b/.github/ISSUE_TEMPLATE/egg-request.yml
@@ -27,7 +27,7 @@ body:
     id: download-link
     attributes:
       label: Links for the download
-      description: This needs to be an official link and not one that is hosted on some forum page or a personal Github page.
+      description: This needs to be an official link and not one that is hosted on some forum page or a personal Github page. Docker image is not a viable option.
     validations:
       required: true
     validations:
@@ -36,7 +36,6 @@ body:
     id: instruction-link
     attributes:
       label: Links for the install docs
-      description: Link to install instructions or documentation based on which the server can be created
-      placeholder: Install the server, start it, play
+      description: Link to installation instructions or documentation covering required dependencies and configuration for the server creation. Docker image is not installation documentation!
     validations:
       required: true


### PR DESCRIPTION
# Description

Specify that a docker image is not a viable download link or installation documentation, since so many requests appear to simply have a link to the docker hub.

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done. You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

