### PR TITLE
Correct Failed Installer

### DIFF
--- a/game_eggs/steamcmd_servers/tower_unite/egg-tower-unite.json
+++ b/game_eggs/steamcmd_servers/tower_unite/egg-tower-unite.json
@@ -12,7 +12,7 @@
         "steam_disk_space"
     ],
     "images": [
-        "quay.io\/pterodactyl\/core:source"
+        "ghcr.io/pterodactyl/games:source"
     ],
     "file_denylist": [],
     "startup": ".\/Tower\/Binaries\/Linux\/TowerServer-Linux-Shipping -log -Port={{SERVER_PORT}} -MULTIHOME=0.0.0.0 -TowerServerINI=..\/..\/Saved\/Config\/TowerServer.ini",
@@ -24,8 +24,8 @@
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/bash\r\n# Tower Unite Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\napt -y update\r\napt -y --install-recommends install curl ca-certificates lib32gcc1\r\n\r\ncd \/tmp\r\ncurl -sSL -o steamcmd.tar.gz http:\/\/media.steampowered.com\/installer\/steamcmd_linux.tar.gz\r\n\r\nmkdir -p \/mnt\/server\/steamcmd\r\n\r\ntar -xzvf steamcmd.tar.gz -C \/mnt\/server\/steamcmd\r\n\r\ncd \/mnt\/server\/steamcmd\r\n\r\n# SteamCMD fails otherwise for some reason, even running as root.\r\n# This is changed at the end of the install process anyways.\r\nchown -R root:root \/mnt\r\n\r\nexport HOME=\/mnt\/server\r\n.\/steamcmd.sh +login anonymous +force_install_dir \/mnt\/server +app_update 439660 validate +quit\r\n\r\ncd mnt\/server\r\n\r\nmkdir -p Tower\/Saved\/Config\r\nmkdir -p Tower\/Binaries\/Linux\r\n\r\nmv \/mnt\/server\/steamcmd\/linux64\/steamclient.so \/mnt\/server\/Tower\/Binaries\/Linux\r\n\r\ncat <<EOF >> Tower\/Saved\/Config\/TowerServer.ini\r\n[\/script\/towernetworking.dedicatedserveroptions]\r\nMaxPlayers=$SERVER_MAX_PLAYER\r\nServerTitle=$SERVER_TITLE\r\nSteamLoginToken=$STEAM_LOGIN_TOKEN\r\n\r\n[Administration]\r\nAdminSteamID=$STEAM_ADMIN_ID\r\nEOF",
-            "container": "ubuntu:18.10",
+            "script": "#!\/bin\/bash\r\n# Tower Unite Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\napt -y update\r\napt -y --install-recommends install curl ca-certificates lib32gcc-s1\r\n\r\ncd \/tmp\r\ncurl -sSL -o steamcmd.tar.gz http:\/\/media.steampowered.com\/installer\/steamcmd_linux.tar.gz\r\n\r\nmkdir -p \/mnt\/server\/steamcmd\r\n\r\ntar -xzvf steamcmd.tar.gz -C \/mnt\/server\/steamcmd\r\n\r\ncd \/mnt\/server\/steamcmd\r\n\r\n# SteamCMD fails otherwise for some reason, even running as root.\r\n# This is changed at the end of the install process anyways.\r\nchown -R root:root \/mnt\r\n\r\nexport HOME=\/mnt\/server\r\n.\/steamcmd.sh +login anonymous +force_install_dir \/mnt\/server +app_update 439660 validate +quit\r\n\r\ncd mnt\/server\r\n\r\nmkdir -p Tower\/Saved\/Config\r\nmkdir -p Tower\/Binaries\/Linux\r\n\r\nmv \/mnt\/server\/steamcmd\/linux64\/steamclient.so \/mnt\/server\/Tower\/Binaries\/Linux\r\n\r\ncat <<EOF >> Tower\/Saved\/Config\/TowerServer.ini\r\n[\/script\/towernetworking.dedicatedserveroptions]\r\nMaxPlayers=$SERVER_MAX_PLAYER\r\nServerTitle=$SERVER_TITLE\r\nSteamLoginToken=$STEAM_LOGIN_TOKEN\r\n\r\n[Administration]\r\nAdminSteamID=$STEAM_ADMIN_ID\r\nEOF",
+            "container": "ghcr.io/pterodactyl/installers:debian",
             "entrypoint": "bash"
         }
     },


### PR DESCRIPTION
# Description

Egg fails to install due to ubuntu installer package issues. Switched to debian, changed gcc package name. Also updated from quay to ghcr

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done. You can click preview to make the links appear clickable. -->

* [X ] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [ X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [ X] Have you tested and reviewed your changes with confidence that everything works?
* [ X] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:
