### PR TITLE
project_zomboid image

### DIFF
--- a/game_eggs/steamcmd_servers/project_zomboid/egg-project-zomboid.json
+++ b/game_eggs/steamcmd_servers/project_zomboid/egg-project-zomboid.json
@@ -12,7 +12,7 @@
         "steam_disk_space"
     ],
     "images": [
-        "ghcr.io\/pterodactyl\/games:source"
+        "ghcr.io\/parkervcp\/games:source"
     ],
     "file_denylist": [],
     "startup": "\/home\/container\/start-server.sh -port {{SERVER_PORT}} -steamport1 {{STEAM_PORT}} -cachedir=\/home\/container\/.cache -servername \"{{SERVER_NAME}}\" -adminusername {{ADMIN_USER}} -adminpassword \"{{ADMIN_PASSWORD}}\"",


### PR DESCRIPTION


# Description

When running ghcr.io/pterodactyl/games:source image the installation of project zomboid will never complete. Proposing to change it to ghcr.io/parkervcp/games:source image.

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done. You can click preview to make the links appear clickable. -->

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- You can erase the new egg submission template if you're not adding a completely new egg -->

## New egg Submissions

1. [ ] Does your submission pass tests (server is connectable)?
2. [ ] Does your egg use a custom docker image?
    * [ ] Have you tried to use a generic image?
    * [ ] Did you PR the necessary changes to make it work?
3. [ ] Have you added the egg to the main README.md and any other README files in subdirectories of the egg (e.g /game_eggs) according to the alphabetical order?
4. [ ] Have you added a unique README.md for the egg you are adding according to the alphabetical order?