### PR TITLE
Update Project Zomboid egg

### DIFF
--- a/game_eggs/steamcmd_servers/project_zomboid/egg-project-zomboid.json
+++ b/game_eggs/steamcmd_servers/project_zomboid/egg-project-zomboid.json
@@ -12,7 +12,7 @@
         "steam_disk_space"
     ],
     "images": [
-        "ghcr.io\/pterodactyl\/games:source"
+        "ghcr.io\/parkervcp\/games:source"
     ],
     "file_denylist": [],
     "startup": "\/home\/container\/start-server.sh -port {{SERVER_PORT}} -steamport1 {{STEAM_PORT}} -cachedir=\/home\/container\/.cache -servername \"{{SERVER_NAME}}\" -adminusername {{ADMIN_USER}} -adminpassword \"{{ADMIN_PASSWORD}}\"",


### PR DESCRIPTION
# Description

When running ghcr.io/pterodactyl/games:source image the server will not start up. Proposing to change it to ghcr.io/parkervcp/games:source image which fixes the problem.

## Checklist for all submissions

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you tested and reviewed your changes with confidence that everything works?
* [X] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?: