### PR TITLE
Update rust (lang) egg

### DIFF
--- a/bots/discord/README.md
+++ b/bots/discord/README.md
@@ -27,6 +27,10 @@ A generic discord.js egg for running discord bots.
 [discord.py](https://discordpy.readthedocs.io/en/latest/)
 A generic discord.py egg for running discord bots.
 
+### [DiscordRS](discord.rs)
+
+A generic Rust application egg.
+
 ### [discordgo](discordgo)
 
 [discordgo](https://github.com/bwmarrin/discordgo)

--- a/bots/discord/discord.rs/egg-discord-rs-generic.json
+++ b/bots/discord/discord.rs/egg-discord-rs-generic.json
@@ -1,25 +1,25 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
-        "version": "PTDL_v1",
+        "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2022-04-17T16:56:51+01:00",
-    "name": "discord.rs generic",
-    "author": "ethan.coward@icloud.com",
+    "exported_at": "2022-09-15T21:15:45+01:00",
+    "name": "rust lang generic",
+    "author": "ethan@ethancoward.dev",
     "description": "Creates a container that runs rust with cargo.",
     "features": null,
-    "images": [
-        "ghcr.io\/parkervcp\/yolks:rust_1.31",
-        "ghcr.io\/parkervcp\/yolks:rust_1.56",
-        "ghcr.io\/parkervcp\/yolks:rust_1.60",
-        "ghcr.io\/parkervcp\/yolks:rust_latest"
-    ],
+    "docker_images": {
+        "ghcr.io\/parkervcp\/yolks:rust_latest": "ghcr.io\/parkervcp\/yolks:rust_latest",
+        "ghcr.io\/parkervcp\/yolks:rust_1.60": "ghcr.io\/parkervcp\/yolks:rust_1.60",
+        "ghcr.io\/parkervcp\/yolks:rust_1.56": "ghcr.io\/parkervcp\/yolks:rust_1.56",
+        "ghcr.io\/parkervcp\/yolks:rust_1.31": "ghcr.io\/parkervcp\/yolks:rust_1.31"
+    },
     "file_denylist": [],
     "startup": "if [[ -d .git ]] && [[ {{AUTO_UPDATE}} == \"1\" ]]; then git pull; fi; cargo run --release",
     "config": {
         "files": "{}",
-        "startup": "{\r\n    \"done\": [\r\n        \"Finished\"\r\n    ]\r\n}",
+        "startup": "{\r\n    \"done\": [\r\n        \"change this part\"\r\n    ]\r\n}",
         "logs": "{}",
         "stop": "^C"
     },
@@ -38,7 +38,8 @@
             "default_value": "",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "nullable|string"
+            "rules": "nullable|string",
+            "field_type": "text"
         },
         {
             "name": "Git Branch",
@@ -47,7 +48,8 @@
             "default_value": "",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "nullable|string"
+            "rules": "nullable|string",
+            "field_type": "text"
         },
         {
             "name": "Auto Update",
@@ -56,7 +58,8 @@
             "default_value": "0",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|boolean"
+            "rules": "required|boolean",
+            "field_type": "text"
         },
         {
             "name": "Git Username",
@@ -65,7 +68,8 @@
             "default_value": "",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "nullable|string"
+            "rules": "nullable|string",
+            "field_type": "text"
         },
         {
             "name": "Git Access Token",
@@ -74,16 +78,8 @@
             "default_value": "",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "nullable|string"
-        },
-        {
-            "name": "Bot Token",
-            "description": "The discord token used to run your bot. Sets to the environment variable `DISCORD_TOKEN`\r\n\r\nAlternatively, you can use a .env file",
-            "env_variable": "DISCORD_TOKEN",
-            "default_value": "",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": "nullable|string"
+            "rules": "nullable|string",
+            "field_type": "text"
         }
     ]
 }


### PR DESCRIPTION
# Description

<!-- Please explain what is being changed or added as a short overview for this PR. Also, link existing relevant issues if they exist with resolves # -->
- Edit the rust egg to re-order rust versions from most recent to oldest - so that the default yolk used is rust_latest. 
- This PR also removes the DISCORD_TOKEN env variable as creating a .env file or other config file is a better way to store secrets such as a discord bot token.

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done. You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

While there isn't a PR to re-order the rust docker images to make more sense, #1774 includes the change of removing the DISCORD_TOKEN env variable so that change could be removed from this PR.