### PR TITLE
Update Minecraft Magma

### DIFF
--- a/game_eggs/minecraft/java/magma/README.md
+++ b/game_eggs/minecraft/java/magma/README.md
@@ -11,3 +11,7 @@ The minecraft server requires a single port for access (default 25565) but plugi
 | Port  | default |
 |-------|---------|
 | Game  | 25565   |
+
+## Notes
+Providing a Minecraft version of ``latest`` or an empty value will default to 1.18.2 as this is the latest version that Magma supports at this time.
+There is no API to query to find the true latest supported version.

--- a/game_eggs/minecraft/java/magma/egg-magma.json
+++ b/game_eggs/minecraft/java/magma/egg-magma.json
@@ -1,10 +1,10 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
-        "version": "PTDL_v1",
+        "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2022-05-22T00:20:47-04:00",
+    "exported_at": "2022-09-28T18:19:11+00:00",
     "name": "Magma",
     "author": "support@pterodactyl.io",
     "description": "Magma is most powerful Forge server providing you with Forge mods and Bukkit Plugins using Spigot and Paper for Performance Optimization and Stability.",
@@ -13,11 +13,12 @@
         "java_version",
         "pid_limit"
     ],
-    "images": [
-        "ghcr.io\/pterodactyl\/yolks:java_8",
-        "ghcr.io\/pterodactyl\/yolks:java_11",
-        "ghcr.io\/pterodactyl\/yolks:java_17"
-    ],
+    "docker_images": {
+        "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
+        "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
+        "Java 11": "ghcr.io\/pterodactyl\/yolks:java_11",
+        "Java 8": "ghcr.io\/pterodactyl\/yolks:java_8"
+    },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",
     "config": {
@@ -28,8 +29,8 @@
     },
     "scripts": {
         "installation": {
-            "script": "apt update\r\napt install -y curl jq\r\n\r\nif [[ ! -d \/mnt\/server ]]; then\r\n  mkdir \/mnt\/server\r\nfi\r\n\r\ncd \/mnt\/server\/\r\n\r\n# get release info and download links\r\nLATEST_JSON=$(curl --silent \"https:\/\/api.magmafoundation.org\/api\/v2\/1.16.5\/latest\")\r\n\r\nif [[ -z \"${TAG_VERSION}\" ]]; then\r\n  TAG_VERSION = \"latest\"\r\nfi\r\n\r\nif [[ -z \"${MC_VERSION}\" ]] || [[ \"${MC_VERSION}\" == \"latest\" ]]; then\r\n  echo -e \"Version not set. Defaulting to latest\"\r\n  DOWNLOAD_LINK=$(echo ${LATEST_JSON} | jq -r .link | grep -i installer.jar)\r\nelif [[ $MC_VERSION =~ ^1\\.(16|17|18|19|20|21|22|23) ]]; then\r\n  CUSTOM_JSON=$(curl --silent \"https:\/\/api.magmafoundation.org\/api\/v2\/${MC_VERSION}\/${TAG_VERSION}\")\r\n  DOWNLOAD_LINK=$(echo ${CUSTOM_JSON} | jq -r .link | grep -i installer.jar)\r\nelif [[ \"${MC_VERSION}\" == \"1.12\" ]]; then\r\n  CUSTOM_JSON=$(curl --silent \"https:\/\/api.magmafoundation.org\/api\/v2\/1.12\/${TAG_VERSION}\")\r\n  DOWNLOAD_LINK=$(echo ${CUSTOM_JSON} | jq -r .link | grep -i server.jar)\r\nelse\r\n  echo -e \"Specified ${MC_VERSION} version not found. Defaulting to latest\"\r\n  DOWNLOAD_LINK=$(echo ${LATEST_JSON} | jq .link)\r\nfi\r\n\r\n# validate download link\r\nif [ ! -z \"${DOWNLOAD_LINK}\" ]; then\r\n  echo -e \"Validating download link\"\r\n  if curl --output \/dev\/null --silent --head --fail ${DOWNLOAD_LINK}; then\r\n    echo -e \"link is valid. setting download link to ${DOWNLOAD_LINK}\"\r\n    DOWNLOAD_LINK=${DOWNLOAD_LINK}\r\n  else\r\n    echo -e \"Download URL ${DOWNLOAD_LINK} is invalid. Terminating install.\"\r\n    exit 2\r\n  fi\r\nfi\r\n\r\nfunction downloadMagma {\r\n  echo -e \"running: curl -sSL -o installer.jar ${DOWNLOAD_LINK}\"\r\n  curl -sSL -o installer.jar -sSL ${DOWNLOAD_LINK}\r\n}\r\n\r\nif [[ $MC_VERSION =~ ^1\\.(16|17|18|19|20|21|22|23) ]] || [[ -z \"${MC_VERSION}\" ]] || [[ \"${MC_VERSION}\" == \"latest\" ]] ; then\r\n  downloadMagma\r\n  echo -e \"1.16.5 or newer version detected. Running installer\"\r\n  java -jar installer.jar --installServer || { echo -e \"install failed\" exit 4; }\r\n  mv forge-*.jar $SERVER_JARFILE\r\n  echo -e \"Deleting installer.jar file.\\n\"\r\n  rm -rf *installer.jar\r\nelse\r\n  downloadMagma\r\n  echo -e \"Older magma version detected. Skipping installer\"\r\n  mv installer.jar $SERVER_JARFILE\r\nfi\r\n\r\necho -e \"Install Complete\"",
-            "container": "openjdk:8-jdk-slim",
+            "script": "apt update\r\napt install -y curl jq\r\n\r\ncd \/mnt\/server\/\r\n\r\n# Hard coded latest version as the magma API doesn't have an endpoint to query for it\r\nLATEST_VERSION=\"1.18.2\"\r\n\r\n# Default TAG_VERSION if empty\r\nif [[ -z \"${TAG_VERSION}\" ]]; then\r\n    TAG_VERSION=\"latest\"\r\nfi\r\n\r\n\r\nif [[ -z \"${MC_VERSION}\" ]] || [[ \"${MC_VERSION}\" == \"latest\" ]]; then\r\n    echo -e \"Version not set. Defaulting to latest\"\r\n    MC_VERSION=${LATEST_VERSION}\r\nfi\r\n\r\necho \"Attempting to install Magma - Version ${MC_VERSION} - Tag ${TAG_VERSION}\"\r\n\r\nif [[ \"${TAG_VERSION}\" == \"latest\" ]]; then\r\n    # Didn't ask for a specific tag\r\n    VERSION_JSON=$(curl --silent \"https:\/\/api.magmafoundation.org\/api\/v2\/${MC_VERSION}\/latest\")\r\nelse\r\n    # Asked for a specific tag\r\n    VERSION_JSON=$(curl --silent \"https:\/\/api.magmafoundation.org\/api\/v2\/${MC_VERSION}\/latest\/${TAG_VERSION}\")\r\nfi\r\n\r\nDOWNLOAD_LINK=$(echo ${VERSION_JSON} | jq -r .link)\r\necho \"Download Link: '${DOWNLOAD_LINK}'\"\r\n\r\n# Check we found a download link\r\nif [ ! -z \"${DOWNLOAD_LINK}\" ]; then\r\n    \r\n    # Validate that link works\r\n    echo -e \"Validating download link\"\r\n    if curl --output \/dev\/null --silent --head --fail ${DOWNLOAD_LINK}; then\r\n        echo -e \"link is valid. setting download link to ${DOWNLOAD_LINK}\"\r\n        DOWNLOAD_LINK=${DOWNLOAD_LINK}\r\n    else\r\n        echo -e \"Download URL ${DOWNLOAD_LINK} is invalid. Terminating install.\"\r\n        exit 2\r\n    fi\r\nelse\r\n    echo -e \"No download URL found. Terminating install.\"\r\n    exit 2\r\nfi\r\n\r\n\r\n# Download server.jar\r\necho -e \"running: curl -sSL -o ${SERVER_JARFILE} ${DOWNLOAD_LINK}\"\r\ncurl -sSL -o ${SERVER_JARFILE} -sSL ${DOWNLOAD_LINK}\r\necho -e \"Install Complete\"",
+            "container": "ghcr.io\/parkervcp\/installers:debian",
             "entrypoint": "bash"
         }
     },
@@ -41,7 +42,8 @@
             "default_value": "server.jar",
             "user_viewable": true,
             "user_editable": false,
-            "rules": "required|regex:\/^([\\w\\d._-]+)(\\.jar)$\/"
+            "rules": "required|regex:\/^([\\w\\d._-]+)(\\.jar)$\/",
+            "field_type": "text"
         },
         {
             "name": "Minecraft Version",
@@ -50,7 +52,8 @@
             "default_value": "latest",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "nullable|string|max:20"
+            "rules": "nullable|string|max:20",
+            "field_type": "text"
         },
         {
             "name": "Tag Version",
@@ -59,7 +62,8 @@
             "default_value": "latest",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "nullable|string|max:20"
+            "rules": "nullable|string|max:20",
+            "field_type": "text"
         }
     ]
 }


### PR DESCRIPTION
# Description

Current version of the Magma egg fails to generate valid download URLs and (even if it did) for some versions attempts to use the Magma installers that are currently broken on most/all versions.

- Re-work install script
- Add new java images and update to labeled java format
- Hardcodes latest version hard coded to  1.18.2 as there is no API to find latest supported MC version

I have tested this updated egg by installing all 3 current available versions of Magma, as well as installing one version by specific build tag. In all cases the jar was installed and loaded up correctly.



Note that although #1846 was caused by things being broken in a different way, acceptance of the PR should warrant closing #1846 as any issues with the egg that *may* have existed would not longer exist.


## Checklist for all submissions

<!-- insert X into the brackets to mark it as done. You can click preview to make the links appear clickable. -->

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you tested and reviewed your changes with confidence that everything works?
* [X] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:
