### PR TITLE
Re-order rust yolks

### DIFF
--- a/generic/rust/egg-rust-generic.json
+++ b/generic/rust/egg-rust-generic.json
@@ -4,22 +4,22 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2022-07-25T14:36:57-04:00",
+    "exported_at": "2022-10-01T18:32:46+01:00",
     "name": "rust generic",
-    "author": "ethan.coward@icloud.com",
+    "author": "ethan@ethancoward.dev",
     "description": "Creates a container that runs rust with cargo.",
     "features": null,
     "docker_images": {
-        "ghcr.io\/parkervcp\/yolks:rust_1.31": "ghcr.io\/parkervcp\/yolks:rust_1.31",
-        "ghcr.io\/parkervcp\/yolks:rust_1.56": "ghcr.io\/parkervcp\/yolks:rust_1.56",
+        "ghcr.io\/parkervcp\/yolks:rust_latest": "ghcr.io\/parkervcp\/yolks:rust_latest",
         "ghcr.io\/parkervcp\/yolks:rust_1.60": "ghcr.io\/parkervcp\/yolks:rust_1.60",
-        "ghcr.io\/parkervcp\/yolks:rust_latest": "ghcr.io\/parkervcp\/yolks:rust_latest"
+        "ghcr.io\/parkervcp\/yolks:rust_1.56": "ghcr.io\/parkervcp\/yolks:rust_1.56",
+        "ghcr.io\/parkervcp\/yolks:rust_1.31": "ghcr.io\/parkervcp\/yolks:rust_1.31"
     },
     "file_denylist": [],
     "startup": "if [[ -d .git ]] && [[ {{AUTO_UPDATE}} == \"1\" ]]; then git pull; fi; cargo run --release",
     "config": {
         "files": "{}",
-        "startup": "{\r\n    \"done\": [\r\n        \"Finished\"\r\n    ]\r\n}",
+        "startup": "{\r\n    \"done\": [\r\n        \"change this part\"\r\n    ]\r\n}",
         "logs": "{}",
         "stop": "^C"
     },


### PR DESCRIPTION
# Description

<!-- Please explain what is being changed or added as a short overview for this PR. Also, link existing relevant issues if they exist with resolves # -->
This PR re-orders the Rust yolks so that the default yolk used is rust_latest

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done. You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?

<!-- You can erase the new egg submission template if you're not adding a completely new egg -->
