### PR TITLE
Updated Pavlov VR README with new information

### DIFF
--- a/game_eggs/steamcmd_servers/pavlov_vr/README.md
+++ b/game_eggs/steamcmd_servers/pavlov_vr/README.md
@@ -1,26 +1,25 @@
 # Pavlov VR
 
-Pavlov VR is a multiplayer shooter in VR with heavy focus on community features. Realistic reloading features and fast paced combat as part of the core experience.
+Pavlov VR is a multiplayer shooter in VR with heavy focus on community features. Realistic reloading features and fast-paced combat as part of the core experience.
 
 ## Recommended server settings
 
 ### Minimum RAM
 
-This server requires about 2048M to run. A 3.2 GHz core will support approximately 24 players. Since Pavlov VR is single threaded, faster clockspeeds will mean higher performance.
-
-### Tickrate
-
-For stable results, please use a minimum of 50 and a maximum of 120.
+This server requires about 2048M to run. A 3.2 GHz core will support approximately 24 players. Since Pavlov VR is single threaded, faster clock-speeds will mean higher performance.
 
 ### Multiple Servers on the same host
 
-If you are running multiple servers and have set additional ports (see <http://wiki.pavlov-vr.com/index.php?title=Dedicated_server#Running_multiple_servers_on_one_host>) then you need to allow access to the defined port plus the port 400 higher. So if you use 7000 as your port, then UDP 7000 and 7400 need to be open.
+If you are running multiple servers and have set additional ports (see [Running multiple servers](http://wiki.pavlov-vr.com/index.php?title=Dedicated_server#Running_multiple_servers_on_one_host)) then you need to allow access to the defined port plus the port 400 higher. So if you use 7000 as your port, then UDP 7000 and 7400 need to be open.
 
-For additional help, please see the following - <http://wiki.pavlov-vr.com/index.php?title=Dedicated_server>
 
 ### Steam Workshop
 
 When downloading a large map from the steam workshop make sure your node has enough RAM assigned to store the map files in its tmpfs! This requires you to modify your wings configuration to have the tmpfs_size value increased.
+
+Additionally, due to the way Pavlov stores workshop maps in the temp directory, the only way to persistently keep workshop maps is to create a mount for /tmp/workshop. For assistance with mounts, please visit the following link - [Using Mounts Pterodactyl](https://pterodactyl.io/guides/mounts.html)
+
+For additional help, please see the following - [Dedicated Server Wiki](http://wiki.pavlov-vr.com/index.php?title=Dedicated_server)
 
 ## Server Ports
 


### PR DESCRIPTION

Updated the Pavlov VR Egg's README with new information that is inherently important to operation around Pterodactyl., cleaned up the wiki links and removed the unnecessary tick rate option. It's not recommended to change; therefore let's ignore it's existence. However, /tmp/workshop is an important thing to note for Pterodactyl users as otherwise the server re-downloads workshop maps every time and that just seems silly.

# Description

<!-- Please explain what is being changed or added as a short overview for this PR. Also, link existing relevant issues if they exist with resolves # -->

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done. You can click preview to make the links appear clickable. -->

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?: 
