### PR TITLE
Fixing MongoDB 6 authentification

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ If you are reading this it looks like you are looking to add an egg to your serv
 
 ### noSQL
 
-* [mongoDB](/database/nosql/mongodb)
+* [MongoDB](/database/nosql/mongodb)
 
 ### SQL Databases
 

--- a/database/nosql/mongodb/README.md
+++ b/database/nosql/mongodb/README.md
@@ -1,4 +1,4 @@
-# mongoDB
+# MongoDB
 
 ## From their [Website](https://www.mongodb.com/)
 

--- a/database/nosql/mongodb/README.md
+++ b/database/nosql/mongodb/README.md
@@ -14,18 +14,29 @@ By default, MongoDB **does not enforce access control**, meaning that even if yo
 
 > :warning: This is why we recommend to expose your MongoDB database only to your local network, if possible
 
+### Enabling authentication
+
+To enable authentification, you need to edit the following lines to your `mongod.conf` file:
+
+```yaml
+security:
+  authorization: "enabled"
+```
+
+> :closed_lock_with_key: To learn more about MongoDB security, you can read the [MongoDB Security Checklist](https://www.mongodb.com/docs/manual/administration/security-checklist/#security-checklist)
+
 ### Notes specific to the MongoDB 6 egg
 
-The [MongoDB 6 egg](./egg-mongo-d-b6.json) enables access control by default in the `mongod.conf` file, meaning that even if people will be able to connect to your database as guests, [they will not be able to perform any operation, apart from nonhazardous commands](https://dba.stackexchange.com/a/292175)
+**The [MongoDB 6 egg](./egg-mongo-d-b6.json) enables access control by default** in the `mongod.conf` file, meaning that even if people will be able to connect to your database as guests, [they will not be able to perform any operation, apart from nonhazardous commands](https://dba.stackexchange.com/a/292175)
 
-### :warning: If you know what you are doing, and you really want to disable access control, you can do so by editing the `mongod.conf` file
+### Disabling authentication
+
+**If you know what you are doing** and want to explicitly disable access control, you can edit the following lines to your `mongod.conf` file:
 
 ```yaml
 security:
   authorization: "disabled"
 ```
-
-> To learn more about MongoDB security, you can read the [MongoDB Security Checklist](https://www.mongodb.com/docs/manual/administration/security-checklist/#security-checklist)
 
 ## Minimum RAM warning
 

--- a/database/nosql/mongodb/README.md
+++ b/database/nosql/mongodb/README.md
@@ -8,6 +8,25 @@ MongoDB is a general purpose, document-based, distributed database built for mod
 
 To disable the message about free monitoring you can run `db.disableFreeMonitoring()`.
 
+## Security
+
+By default, MongoDB **does not enforce access control**, meaning that even if you set an admin username and password in the settings of your Pterodactyl server, **anyone will be able to connect to the database without authentication**, and perform any operation.
+
+> :warning: This is why we recommend to expose your MongoDB database only to your local network, if possible
+
+### Notes specific to the MongoDB 6 egg
+
+The [MongoDB 6 egg](./egg-mongo-d-b6.json) enables access control by default in the `mongod.conf` file, meaning that even if people will be able to connect to your database as guests, [they will not be able to perform any operation, apart from nonhazardous commands](https://dba.stackexchange.com/a/292175)
+
+### :warning: If you know what you are doing, and you really want to disable access control, you can do so by editing the `mongod.conf` file
+
+```yaml
+security:
+  authorization: "disabled"
+```
+
+> To learn more about MongoDB security, you can read the [MongoDB Security Checklist](https://www.mongodb.com/docs/manual/administration/security-checklist/#security-checklist)
+
 ## Minimum RAM warning
 
 MongoDB requires approximately 1GB of RAM per 100.000 assets. If the system has to start swapping memory to disk, this will have a severely negative impact on performance, and should be avoided.

--- a/database/nosql/mongodb/egg-mongo-d-b6.json
+++ b/database/nosql/mongodb/egg-mongo-d-b6.json
@@ -15,7 +15,7 @@
     "file_denylist": [],
     "startup": "mongod --fork --dbpath \/home\/container\/mongodb\/ --port ${SERVER_PORT} --bind_ip 0.0.0.0 --logpath \/home\/container\/logs\/mongo.log -f \/home\/container\/mongod.conf; until nc -z -v -w5 127.0.0.1 ${SERVER_PORT}; do echo 'Waiting for mongodb connection...'; sleep 5; done; mongosh --username ${MONGO_USER} --password ${MONGO_USER_PASS} --host 127.0.0.1:${SERVER_PORT} && mongosh --eval \"db.getSiblingDB('admin').shutdownServer()\" 127.0.0.1:${SERVER_PORT}",
     "config": {
-        "files": "{}",
+        "files": "{\r\n    \"mongod.conf\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"#security:\": \"security: \\r\\n  authorization: \\\"enabled\\\"\"\r\n        }\r\n    }\r\n}",
         "startup": "{\r\n    \"done\": \"child process started successfully\"\r\n}",
         "logs": "{}",
         "stop": "exit"

--- a/database/nosql/mongodb/egg-mongo-d-b6.json
+++ b/database/nosql/mongodb/egg-mongo-d-b6.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2022-09-27T08:58:45-04:00",
+    "exported_at": "2022-10-31T17:26:13+00:00",
     "name": "MongoDB 6",
     "author": "parker@parkervcp.com",
     "description": "MongoDB is a general purpose, document-based, distributed database built for modern application developers and for my butt era.",


### PR DESCRIPTION
# Description

After a few days of use, I exposed my database publicly because I needed to debug my code, and I used MongoDB Compass to do so. I left my database exposed to the internet for a few hours, and the next day when I came back to continue working on my code, I noticed that my database had been the victim of an automated ransomware attack.

After checking, I noticed that authentication was not applied by default on the MongoDB 6 egg, even though an administrator username and password were set on Pterodactyl, leaving my database accessible to literally anyone.

So I checked the MongoDB documentation to see how to enable access control, and after editing the config file, the change does indeed provide access control. So I modified the MongoDB 6 egg to automatically activate this option in the configuration, and I also modified the README to add some indications from a security point of view on MongoDB.

## Checklist for all submissions

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you tested and reviewed your changes with confidence that everything works?
* [X] Did you branch your changes and PR from that branch and not from your master branch?
