### PR TITLE
Updated FlameCord To be build from source

### DIFF
--- a/game_eggs/minecraft/proxy/java/flamecord/egg-flamecord.json
+++ b/game_eggs/minecraft/proxy/java/flamecord/egg-flamecord.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2022-11-13T12:25:46+00:00",
+    "exported_at": "2022-12-19T17:57:16+01:00",
     "name": "Flamecord",
     "author": "admin@softwarenoob.com",
     "description": "FlameCord is a patch for Travertine to fix possible exploits and add useful functionalities. FlameCord aims to fix Netty related exploits to keep your server safe from attacks.",
@@ -16,8 +16,7 @@
     "docker_images": {
         "ghcr.io\/pterodactyl\/yolks:java_17": "ghcr.io\/pterodactyl\/yolks:java_17",
         "ghcr.io\/pterodactyl\/yolks:java_16": "ghcr.io\/pterodactyl\/yolks:java_16",
-        "ghcr.io\/pterodactyl\/yolks:java_11": "ghcr.io\/pterodactyl\/yolks:java_11",
-        "ghcr.io\/pterodactyl\/yolks:java_8": "ghcr.io\/pterodactyl\/yolks:java_8"
+        "ghcr.io\/pterodactyl\/yolks:java_11": "ghcr.io\/pterodactyl\/yolks:java_11"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",
@@ -29,8 +28,8 @@
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/bash\r\n# FlameCord Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\napt update\r\napt install -y curl unzip\r\n# Get download link\r\necho -e \"Downloading latest FlameCord build\"\r\nDOWNLOAD_URL=https:\/\/nightly.link\/Permanently\/FlameCord\/workflows\/flamecord-build\/master\/FlameCord-JDK11.zip\r\ncd \/mnt\/server\r\necho -e \"curl -L ${DOWNLOAD_URL} -o flamecord.zip\"\r\ncurl -L ${DOWNLOAD_URL} -o flamecord.zip\r\nif [ -f ${SERVER_JARFILE} ]; then\r\nmv ${SERVER_JARFILE} ${SERVER_JARFILE}.old\r\nfi\r\nunzip flamecord.zip\r\nmv FlameCord.jar ${SERVER_JARFILE}\r\nrm flamecord.zip\r\necho \"Install complete\"",
-            "container": "debian:buster-slim",
+            "script": "#!\/bin\/bash\r\n# FlameCord Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\napt update\r\napt install -y curl git \r\n\r\nmkdir -p \/mnt\/server\/tmp\r\ncd \/mnt\/server\/tmp\r\n\r\nrm \/mnt\/server\/${SERVER_JARFILE}\r\n# set some needed variables\r\ngit config --global user.email \"you@example.com\"\r\ngit config --global user.name \"Your Name\"\r\n\r\n# Clone the repo \r\necho \"git clone https:\/\/github.com\/2lstudios-mc\/FlameCord.git\"\r\ngit clone https:\/\/github.com\/2lstudios-mc\/FlameCord.git \r\ncd FlameCord\/\r\nchmod +x scripts\/build.sh\r\n\r\n#build the jar\r\necho \"start building\"\r\n.\/scripts\/build.sh --jar\r\n\r\n# Find the jar file and move it\r\nJAR_PATH=$(find . -name FlameCord.jar)\r\nmv ${JAR_PATH} \/mnt\/server\/${SERVER_JARFILE}\r\nrm -rf \/mnt\/server\/tmp\r\n\r\necho \"Install complete\"",
+            "container": "maven:3.8.6-openjdk-11-slim",
             "entrypoint": "bash"
         }
     },

--- a/game_eggs/minecraft/proxy/java/flamecord/egg-flamecord.json
+++ b/game_eggs/minecraft/proxy/java/flamecord/egg-flamecord.json
@@ -29,21 +29,12 @@
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/bash\r\n# FlameCord Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\napt update\r\napt install -y curl\r\n\r\n# Get download link\r\nif [ -z \"${FLAMECORD_VERSION}\" ] || [ \"${FLAMECORD_VERSION}\" == \"latest\" ]; then\r\n    echo -e \"Downloading latest FlameCord build\"\r\n    DOWNLOAD_URL=https:\/\/ci.2lstudios.dev\/job\/FlameCord\/lastSuccessfulBuild\/artifact\/FlameCord-Proxy\/bootstrap\/target\/FlameCord.jar\r\nelse \r\n    echo -e \"Downloading FlameCord build ${FLAMECORD_VERSION}\"\r\n    DOWNLOAD_URL=https:\/\/ci.2lstudios.dev\/job\/FlameCord\/${FLAMECORD_VERSION}\/artifact\/FlameCord-Proxy\/bootstrap\/target\/FlameCord.jar\r\nfi\r\n\r\ncd \/mnt\/server\r\n\r\necho -e \"curl -L ${DOWNLOAD_URL} -o ${SERVER_JARFILE}\"\r\n\r\nif [ -f ${SERVER_JARFILE} ]; then\r\n\tmv ${SERVER_JARFILE} ${SERVER_JARFILE}.old\r\nfi\r\n\r\ncurl -L ${DOWNLOAD_URL} -o ${SERVER_JARFILE}\r\necho \"Install complete\"",
+            "script": "#!\/bin\/bash\r\n# FlameCord Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\napt update\r\napt install -y curl unzip\r\n# Get download link\r\necho -e \"Downloading latest FlameCord build\"\r\nDOWNLOAD_URL=https:\/\/nightly.link\/Permanently\/FlameCord\/workflows\/flamecord-build\/master\/FlameCord-JDK11.zip\r\ncd \/mnt\/server\r\necho -e \"curl -L ${DOWNLOAD_URL} -o flamecord.zip\"\r\ncurl -L ${DOWNLOAD_URL} -o flamecord.zip\r\nif [ -f ${SERVER_JARFILE} ]; then\r\nmv ${SERVER_JARFILE} ${SERVER_JARFILE}.old\r\nfi\r\nunzip flamecord.zip\r\nmv FlameCord.jar ${SERVER_JARFILE}\r\nrm flamecord.zip\r\necho \"Install complete\"",
             "container": "debian:buster-slim",
             "entrypoint": "bash"
         }
     },
     "variables": [
-        {
-            "name": "Flamecord Version",
-            "description": "The build to pull and install. (Ex. 97), or set to latest.\r\n\r\nYou can find all builds on https:\/\/ci.2lstudios.dev\/job\/FlameCord\/",
-            "env_variable": "FLAMECORD_VERSION",
-            "default_value": "latest",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": "required|string"
-        },
         {
             "name": "FlameCord Jar File",
             "description": "The name of the jar file to use when running FlameCord.",

--- a/game_eggs/minecraft/proxy/java/flamecord/egg-flamecord.json
+++ b/game_eggs/minecraft/proxy/java/flamecord/egg-flamecord.json
@@ -1,10 +1,10 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
-        "version": "PTDL_v1",
+        "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2022-05-06T10:20:32+02:00",
+    "exported_at": "2022-11-13T12:25:46+00:00",
     "name": "Flamecord",
     "author": "admin@softwarenoob.com",
     "description": "FlameCord is a patch for Travertine to fix possible exploits and add useful functionalities. FlameCord aims to fix Netty related exploits to keep your server safe from attacks.",
@@ -13,12 +13,12 @@
         "java_version",
         "pid_limit"
     ],
-    "images": [
-        "ghcr.io\/pterodactyl\/yolks:java_17",
-        "ghcr.io\/pterodactyl\/yolks:java_16",
-        "ghcr.io\/pterodactyl\/yolks:java_11",
-        "ghcr.io\/pterodactyl\/yolks:java_8"
-    ],
+    "docker_images": {
+        "ghcr.io\/pterodactyl\/yolks:java_17": "ghcr.io\/pterodactyl\/yolks:java_17",
+        "ghcr.io\/pterodactyl\/yolks:java_16": "ghcr.io\/pterodactyl\/yolks:java_16",
+        "ghcr.io\/pterodactyl\/yolks:java_11": "ghcr.io\/pterodactyl\/yolks:java_11",
+        "ghcr.io\/pterodactyl\/yolks:java_8": "ghcr.io\/pterodactyl\/yolks:java_8"
+    },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -Dterminal.jline=false -Dterminal.ansi=true -jar {{SERVER_JARFILE}}",
     "config": {
@@ -51,7 +51,8 @@
             "default_value": "flamecord.jar",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|regex:\/^([\\w\\d._-]+)(\\.jar)$\/"
+            "rules": "required|regex:\/^([\\w\\d._-]+)(\\.jar)$\/",
+            "field_type": "text"
         }
     ]
 }


### PR DESCRIPTION
# Description

FlameCord has taken its permanent download links offline, as well as its Jenkins.  The 2LStudios team stated in their Discord server that they were unable to pay for Jenkins hostings for the time being, and so they've switched to posting pre-compiled downloads on BuiltByBit (formerly MC Market). By making this switch, it has resulted in the egg not breaking, with no official permanent download link.

I have taken it upon myself to reinstate the permanent download links, using GitHub Workflows. This can be viewed on [Permanently/FlameCord](https://github.com/Permanently/FlameCord). The only change that has been made is to the workflows, where the project is compiled in JDK 8, 11 and 17. 

In this egg, I have edited the script so that it downloads the JDK 11 build, unzips the download, and utilises the built FlameCord JAR file inside.

Due to the limitations, I am unable to implement the version specification. I have removed this from the egg. If there are any workarounds that could be used, let me know.

## Checklist for all submissions


* [X] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you tested and reviewed your changes with confidence that everything works?
* [X] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:
