### PR TITLE
Bastion: install script fix double tar cmd + move to python3

### DIFF
--- a/bots/discord/bastion/README.md
+++ b/bots/discord/bastion/README.md
@@ -4,9 +4,6 @@
 
 Bastion is a multi-purpose Discord Bot that can help you automate most tasks in your server, from administration and moderation to keeping the members active through various incentives, games and other fun activities.
 
-## Install notes
-
-There will be a tar error on first install. You can safly ignore this.
 
 ## Running the bot
 

--- a/bots/discord/bastion/egg-bastion.json
+++ b/bots/discord/bastion/egg-bastion.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2022-12-15T16:23:16+01:00",
+    "exported_at": "2022-12-18T10:58:30+01:00",
     "name": "Bastion",
     "author": "parker@parkervcp.com",
     "description": "Bastion is a multi-purpose Discord Bot that can help you automate most tasks in your server, from administration and moderation to keeping the members active through various incentives, games and other fun activities",
@@ -22,7 +22,7 @@
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/bash\r\n# Bastion Bot Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\n## Move to install folder\r\napt update\r\napt install -y build-essential libtool python git tar\r\n\r\nmkdir -p \/mnt\/server\/\r\ncd \/mnt\/server\/\r\n\r\nif [ -d \"\/mnt\/server\/mongodb\" ]\r\nthen\r\n    cd \/mnt\/server\/\r\n    echo \"backing up mongodb\"\r\n    REINSTALL=true\r\n    tar -czf mongodb_backup.tar.gz mongodb\/\r\n    mv mongodb_backup.tar.gz \/tmp\r\nfi\r\n\r\ntar -czf mongodb_back.tar.gz mongodb\/\r\nmv mongodb_back.tar.gz \/tmp\r\n\r\ncd \/mnt\/server\r\nrm -rf * .git\/ .github\/ .env.example .eslintrc.yml .gitattributes .gitignore .npm\/\r\n\r\n\r\n## Clone repo\r\necho \"cloning Bastion bot\"\r\ngit clone -q --depth 1 https:\/\/github.com\/TheBastionBot\/Bastion.git .\/\r\n\r\necho \"npm install --no-package-lock\"\r\nnpm install --no-package-lock\r\necho \"npm run build\"\r\nnpm run build\r\n\r\n## Move config files.\r\nmv settings.example.yaml settings.yaml\r\nrm bastion.cmd .env.example bastion.sh\r\n\r\n\r\nmkdir mongodb\/\r\nif [ \"$REINSTALL\" == \"true\" ]\r\nthen\r\n    cd \/mnt\/server\r\n    echo \"reinstall\"\r\n    mv \/tmp\/mongodb_backup.tar.gz \/mnt\/server\r\n    tar xf mongodb_backup.tar.gz\r\n    rm mongodb_backup.tar.gz\r\nelse\r\n    echo \"fresh install\"\r\nfi\r\n\r\necho \"-----------------------------------------\"\r\necho \"Installation completed...\"\r\necho \"-----------------------------------------\"",
+            "script": "#!\/bin\/bash\r\n# Bastion Bot Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\n## Move to install folder\r\napt update\r\napt install -y build-essential libtool python3 git tar\r\n\r\nmkdir -p \/mnt\/server\/\r\ncd \/mnt\/server\/\r\n\r\nif [ -d \"\/mnt\/server\/mongodb\" ]\r\nthen\r\n    cd \/mnt\/server\/\r\n    echo \"backing up mongodb\"\r\n    REINSTALL=true\r\n    tar -czf mongodb_backup.tar.gz mongodb\/\r\n    mv mongodb_backup.tar.gz \/tmp\r\nfi\r\n\r\ncd \/mnt\/server\r\nrm -rf * .git\/ .github\/ .env.example .eslintrc.yml .gitattributes .gitignore .npm\/\r\n\r\n\r\n## Clone repo\r\necho \"cloning Bastion bot\"\r\ngit clone -q --depth 1 https:\/\/github.com\/TheBastionBot\/Bastion.git .\/\r\n\r\necho \"npm install --no-package-lock\"\r\nnpm install --no-package-lock\r\necho \"npm run build\"\r\nnpm run build\r\n\r\n## Move config files.\r\nmv settings.example.yaml settings.yaml\r\nrm -rf bastion.cmd .env.example bastion.sh scripts\/\r\n\r\n\r\nmkdir -p mongodb\/\r\nif [ \"$REINSTALL\" == \"true\" ]\r\nthen\r\n    cd \/mnt\/server\r\n    echo \"reinstall\"\r\n    mv \/tmp\/mongodb_backup.tar.gz \/mnt\/server\r\n    tar xf mongodb_backup.tar.gz\r\n    rm mongodb_backup.tar.gz\r\nelse\r\n    echo \"fresh install\"\r\nfi\r\n\r\necho \"-----------------------------------------\"\r\necho \"Installation completed...\"\r\necho \"-----------------------------------------\"",
             "container": "node:18-bullseye",
             "entrypoint": "bash"
         }

--- a/bots/discord/bastion/egg-bastion.json
+++ b/bots/discord/bastion/egg-bastion.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2022-12-18T11:27:40+01:00",
+    "exported_at": "2023-03-29T10:33:50+02:00",
     "name": "Bastion",
     "author": "parker@parkervcp.com",
     "description": "Bastion is a multi-purpose Discord Bot that can help you automate most tasks in your server, from administration and moderation to keeping the members active through various incentives, games and other fun activities",
@@ -31,7 +31,7 @@
         {
             "name": "Bot Token",
             "description": "The Bot Token you get from https:\/\/discordapp.com\/developers\/applications\/",
-            "env_variable": "TESSERACT_BOT_TOKEN",
+            "env_variable": "BOT_TOKEN",
             "default_value": "GETABOTTOKEN",
             "user_viewable": true,
             "user_editable": true,
@@ -41,7 +41,7 @@
         {
             "name": "Bot Client ID",
             "description": "The Bot ID you get from https:\/\/discordapp.com\/developers\/applications\/",
-            "env_variable": "TESSERACT_BOT_ID",
+            "env_variable": "BOT_ID",
             "default_value": "",
             "user_viewable": true,
             "user_editable": true,
@@ -51,7 +51,7 @@
         {
             "name": "Mongo URL",
             "description": "use `mongodb:\/\/127.0.0.1:27017\/bastion` for using the build in mongodb server",
-            "env_variable": "TESSERACT_MONGO_URI",
+            "env_variable": "MONGO_URI",
             "default_value": "mongodb:\/\/127.0.0.1:27017\/bastion",
             "user_viewable": true,
             "user_editable": true,
@@ -81,7 +81,7 @@
         {
             "name": "Safe Mode",
             "description": "When enabled, this disables usage of unsafe commands like `exec` and `eval`.",
-            "env_variable": "TESSERACT_UNSAFE_MODE",
+            "env_variable": "UNSAFE_MODE",
             "default_value": "false",
             "user_viewable": true,
             "user_editable": true,

--- a/bots/discord/bastion/egg-bastion.json
+++ b/bots/discord/bastion/egg-bastion.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2022-12-18T10:58:30+01:00",
+    "exported_at": "2022-12-18T11:27:40+01:00",
     "name": "Bastion",
     "author": "parker@parkervcp.com",
     "description": "Bastion is a multi-purpose Discord Bot that can help you automate most tasks in your server, from administration and moderation to keeping the members active through various incentives, games and other fun activities",
@@ -22,7 +22,7 @@
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/bash\r\n# Bastion Bot Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\n## Move to install folder\r\napt update\r\napt install -y build-essential libtool python3 git tar\r\n\r\nmkdir -p \/mnt\/server\/\r\ncd \/mnt\/server\/\r\n\r\nif [ -d \"\/mnt\/server\/mongodb\" ]\r\nthen\r\n    cd \/mnt\/server\/\r\n    echo \"backing up mongodb\"\r\n    REINSTALL=true\r\n    tar -czf mongodb_backup.tar.gz mongodb\/\r\n    mv mongodb_backup.tar.gz \/tmp\r\nfi\r\n\r\ncd \/mnt\/server\r\nrm -rf * .git\/ .github\/ .env.example .eslintrc.yml .gitattributes .gitignore .npm\/\r\n\r\n\r\n## Clone repo\r\necho \"cloning Bastion bot\"\r\ngit clone -q --depth 1 https:\/\/github.com\/TheBastionBot\/Bastion.git .\/\r\n\r\necho \"npm install --no-package-lock\"\r\nnpm install --no-package-lock\r\necho \"npm run build\"\r\nnpm run build\r\n\r\n## Move config files.\r\nmv settings.example.yaml settings.yaml\r\nrm -rf bastion.cmd .env.example bastion.sh scripts\/\r\n\r\n\r\nmkdir -p mongodb\/\r\nif [ \"$REINSTALL\" == \"true\" ]\r\nthen\r\n    cd \/mnt\/server\r\n    echo \"reinstall\"\r\n    mv \/tmp\/mongodb_backup.tar.gz \/mnt\/server\r\n    tar xf mongodb_backup.tar.gz\r\n    rm mongodb_backup.tar.gz\r\nelse\r\n    echo \"fresh install\"\r\nfi\r\n\r\necho \"-----------------------------------------\"\r\necho \"Installation completed...\"\r\necho \"-----------------------------------------\"",
+            "script": "#!\/bin\/bash\r\n# Bastion Bot Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\n## Move to install folder\r\napt update\r\napt install -y build-essential libtool python3 git tar\r\n\r\n\r\nmkdir -p \/mnt\/server\/\r\ncd \/mnt\/server\/\r\n\r\nif [ -d \"\/mnt\/server\/mongodb\" ]\r\nthen\r\n    cd \/mnt\/server\/\r\n    echo \"backing up mongodb\"\r\n    REINSTALL=true\r\n    tar -czf mongodb_backup.tar.gz mongodb\/\r\n    mv mongodb_backup.tar.gz \/tmp\r\nfi\r\n\r\ncd \/mnt\/server\r\nrm -rf * .git\/ .github\/ .env.example .eslintrc.yml .gitattributes .gitignore .npm\/\r\n\r\n\r\n## Clone repo\r\necho \"cloning Bastion bot\"\r\ngit clone -q --depth 1 https:\/\/github.com\/TheBastionBot\/Bastion.git .\/\r\n\r\necho \"updating npm\"\r\nnpm install -g npm@latest\r\necho \"npm install --no-package-lock\"\r\nnpm install --no-package-lock\r\necho \"npm run build\"\r\nnpm run build\r\n\r\n## Move config files.\r\nmv settings.example.yaml settings.yaml\r\nrm -rf bastion.cmd .env.example bastion.sh scrips\/\r\n\r\n\r\nmkdir -p mongodb\/\r\nif [ \"$REINSTALL\" == \"true\" ]\r\nthen\r\n    cd \/mnt\/server\r\n    echo \"reinstall\"\r\n    mv \/tmp\/mongodb_backup.tar.gz \/mnt\/server\r\n    tar xf mongodb_backup.tar.gz\r\n    rm mongodb_backup.tar.gz\r\nelse\r\n    echo \"fresh install\"\r\nfi\r\n\r\necho \"-----------------------------------------\"\r\necho \"Installation completed...\"\r\necho \"-----------------------------------------\"",
             "container": "node:18-bullseye",
             "entrypoint": "bash"
         }


### PR DESCRIPTION
# Description

- move from python 2 to 3 in the install script
- remove a double tar command that would spit out a error on first install
- remove the scripts folder on install as we do not need it

requires: https://github.com/parkervcp/yolks/pull/110

## Checklist for all submissions

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:
