### PR TITLE
Fixed Arma 3 mod loading, removed quote marks around additional params

### DIFF
--- a/game_eggs/steamcmd_servers/arma/arma3/README.md
+++ b/game_eggs/steamcmd_servers/arma/arma3/README.md
@@ -34,6 +34,14 @@ ___
             <a href="https://github.com/parkervcp/eggs/commits?author=IAmSilK" title="Contributor">💡</a>
         </td>
         <td align="center">
+            <a href="https://github.com/Moondarker">
+                <img src="https://avatars.githubusercontent.com/u/4098364" width="50px;" alt=""/><br /><sub><b>Moondarker</b></sub>
+            </a>
+            <br />
+            <a href="https://github.com/parkervcp/eggs/commits?author=Moondarker" title="Codes">💻</a>
+            <a href="https://github.com/parkervcp/eggs/commits?author=Moondarker" title="Contributor">💡</a>
+        </td>
+        <td align="center">
             <a href="https://github.com/Yomanz">
                 <img src="https://avatars.githubusercontent.com/u/5119107" width="50px;" alt=""/><br /><sub><b>Daave</b></sub>
             </a>

--- a/game_eggs/steamcmd_servers/arma/arma3/egg-arma3.json
+++ b/game_eggs/steamcmd_servers/arma/arma3/egg-arma3.json
@@ -14,7 +14,7 @@
         "ghcr.io\/parkervcp\/games:arma3"
     ],
     "file_denylist": [],
-    "startup": ".\/{{SERVER_BINARY}} -ip=0.0.0.0 -port={{SERVER_PORT}} -profiles=.\/serverprofile -bepath=.\/ -cfg=basic.cfg -config=server.cfg -mod=\\\"{{CLIENT_MODS}}\\\" -serverMod=\\\"{{SERVERMODS}}\\\" \\\"{{STARTUP_PARAMS}}\\\"",
+    "startup": ".\/{{SERVER_BINARY}} -ip=0.0.0.0 -port={{SERVER_PORT}} -profiles=.\/serverprofile -bepath=.\/ -cfg=basic.cfg -config=server.cfg \\\"-mod={{CLIENT_MODS}}\\\" \\\"-serverMod={{SERVERMODS}}\\\" {{STARTUP_PARAMS}}",
     "config": {
         "files": "{\r\n    \"server.cfg\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"password=\": \"password = \\\"{{env.SERVER_PASSWORD}}\\\";\",\r\n            \"\/\/password=\": \"password = \\\"{{env.SERVER_PASSWORD}}\\\";\",\r\n            \"password =\": \"password = \\\"{{env.SERVER_PASSWORD}}\\\";\",\r\n            \"\/\/password =\": \"password = \\\"{{env.SERVER_PASSWORD}}\\\";\",\r\n            \"maxPlayers\": \"maxPlayers = {{env.MAX_PLAYERS}};\",\r\n            \"headlessClients\": \"headlessClients[] = { \\\"127.0.0.1\\\" };\",\r\n            \"localClient\": \"localClient[] = { \\\"127.0.0.1\\\" };\"\r\n        }\r\n    }\r\n}",
         "startup": "{\r\n    \"done\": \"Host identity created.\"\r\n}",


### PR DESCRIPTION
# Description
Arma 3 had a classic mistake in `-mod` and `-serverMod` launch options. Quotes must be placed before and after the *entire* argument, not just its value. See [ArmA 3 documentation](https://community.bistudio.com/wiki/Arma_3:_Startup_Parameters#Spaces). If you need further proofs, see what ArmA 3 Launcher itself passes to the game when launched with mods. Same goes for additional startup params, there's no sense in adding quotes right here as it will break once there's more than 1 additional parameter.

In it's current state, given multiple mods like `@Mod 1`, `@Mod 2` and `@Mod 3` as mod list, server will interpret these mods as `"@Mod 1`, `@Mod 2`, `@Mod 3` and `"`

Basically #2021 for ArmA 3

## Checklist for all submissions

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [ ] Have you tested and reviewed your changes with confidence that everything works? 
  * While I'm 146% confident this will work, I haven't tested it personally yet (I don't even have Pterodactyl installed atm)
* [X] Did you branch your changes and PR from that branch and not from your master branch?
