### PR TITLE
Fix Don't Starve Together

### DIFF
--- a/game_eggs/steamcmd_servers/dont_starve/README.md
+++ b/game_eggs/steamcmd_servers/dont_starve/README.md
@@ -21,3 +21,10 @@ Don't Starve Together only requires a single port to run. The default is 10999
 | Game    | 10999   |
 
 ### Mods/Plugins may require ports to be added to the server
+
+### Following ports are used internally and should not be allocated to the server.
+
+| Port   | default |
+|--------|---------|
+| Master | 11000   |
+| Caves  | 11001   |

--- a/game_eggs/steamcmd_servers/dont_starve/egg-don-t-starve-together.json
+++ b/game_eggs/steamcmd_servers/dont_starve/egg-don-t-starve-together.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v1",
         "update_url": null
     },
-    "exported_at": "2021-07-02T04:29:47+03:00",
+    "exported_at": "2023-01-03T01:40:16+02:00",
     "name": "Don't Starve Together",
     "author": "parker@parkervcp.com",
     "description": "Don\u2019t Starve Together is an uncompromising wilderness survival game full of science and magic.",
@@ -15,9 +15,9 @@
         "quay.io\/parkervcp\/pterodactyl-images:debian_source"
     ],
     "file_denylist": [],
-    "startup": "cd bin && coproc caves ( .\/dontstarve_dedicated_server_nullrenderer -console -persistent_storage_root \/home\/container\/DoNotStarveTogether -conf_dir config -cluster server -players {{MAX_PLAYERS}} -shard Caves ); .\/dontstarve_dedicated_server_nullrenderer -bind_ip 0.0.0.0 -port 10999 -console -persistent_storage_root \/home\/container\/DoNotStarveTogether -conf_dir config -cluster server -players {{MAX_PLAYERS}} -shard Master && echo 'c_shutdown()' >&\"${caves[1]}\"",
+    "startup": "cd bin64 && coproc caves ( .\/dontstarve_dedicated_server_nullrenderer_x64 -persistent_storage_root \/home\/container\/DoNotStarveTogether -conf_dir config -cluster server -shard Caves ); .\/dontstarve_dedicated_server_nullrenderer_x64 -persistent_storage_root \/home\/container\/DoNotStarveTogether -conf_dir config -cluster server -shard Master && echo 'c_shutdown()' >&\"${caves[1]}\"",
     "config": {
-        "files": "{\r\n    \"DoNotStarveTogether\/config\/server\/cluster.ini\": {\r\n        \"parser\": \"ini\",\r\n        \"find\": {\r\n            \"GAMEPLAY.game_mode\": \"{{server.build.env.GAME_MODE}}\",\r\n            \"GAMEPLAY.max_players\": \"{{server.build.env.MAX_PLAYERS}}\",\r\n            \"NETWORK.cluster_name\": \"{{server.build.env.CLUSTER_NAME}}\",\r\n            \"NETWORK.cluster_description\": \"{{server.build.env.CLUSTER_DESC}}\",\r\n            \"SHARD.shard_enabled\": \"true\",\r\n            \"SHARD.bind_ip\": \"127.0.0.1\",\r\n            \"SHARD.master_ip\": \"127.0.0.1\",\r\n            \"SHARD.master_port\": \"11001\"\r\n        }\r\n    },\r\n    \"DoNotStarveTogether\/config\/server\/Master\/server.ini\": {\r\n        \"parser\": \"ini\",\r\n        \"find\": {\r\n            \"NETWORK.server_port\": \"{{server.build.default.port}}\",\r\n            \"SHARD.is_master\": \"true\"\r\n        }\r\n    },\r\n    \"DoNotStarveTogether\/config\/server\/Caves\/server.ini\": {\r\n        \"parser\": \"ini\",\r\n        \"find\": {\r\n            \"NETWORK.server_port\": \"11000\",\r\n            \"SHARD.is_master\": \"false\",\r\n            \"SHARD.name\": \"Caves\"\r\n        }\r\n    }\r\n}",
+        "files": "{\r\n    \"DoNotStarveTogether\/config\/server\/cluster.ini\": {\r\n        \"parser\": \"ini\",\r\n        \"find\": {\r\n            \"GAMEPLAY.game_mode\": \"{{server.build.env.GAME_MODE}}\",\r\n            \"GAMEPLAY.max_players\": \"{{server.build.env.MAX_PLAYERS}}\",\r\n            \"NETWORK.cluster_name\": \"{{server.build.env.CLUSTER_NAME}}\",\r\n            \"NETWORK.cluster_description\": \"{{server.build.env.CLUSTER_DESC}}\",\r\n            \"SHARD.shard_enabled\": \"true\",\r\n            \"SHARD.bind_ip\": \"0.0.0.0\",\r\n            \"SHARD.master_ip\": \"127.0.0.1\",\r\n            \"SHARD.master_port\": \"{{server.build.default.port}}\"\r\n        }\r\n    },\r\n    \"DoNotStarveTogether\/config\/server\/Master\/server.ini\": {\r\n        \"parser\": \"ini\",\r\n        \"find\": {\r\n            \"NETWORK.server_port\": \"11000\",\r\n            \"SHARD.is_master\": \"true\"\r\n        }\r\n    },\r\n    \"DoNotStarveTogether\/config\/server\/Caves\/server.ini\": {\r\n        \"parser\": \"ini\",\r\n        \"find\": {\r\n            \"NETWORK.server_port\": \"11001\",\r\n            \"SHARD.is_master\": \"false\",\r\n            \"SHARD.name\": \"Caves\"\r\n        }\r\n    }\r\n}",
         "startup": "{\r\n    \"done\": \"Setting breakpad minidump AppID\",\r\n    \"userInteraction\": []\r\n}",
         "logs": "{}",
         "stop": "c_shutdown()"

--- a/game_eggs/steamcmd_servers/dont_starve/server.caves.ini
+++ b/game_eggs/steamcmd_servers/dont_starve/server.caves.ini
@@ -2,9 +2,9 @@
 encode_user_path = true
 
 [NETWORK]
-server_port = 11000
+server_port = 11001
 
 [SHARD]
 is_master = false
 name = Caves
-id = 1137196188
+id = 2

--- a/game_eggs/steamcmd_servers/dont_starve/server.cluster.ini
+++ b/game_eggs/steamcmd_servers/dont_starve/server.cluster.ini
@@ -17,7 +17,7 @@ console_enabled = true
 
 [SHARD]
 shard_enabled = true
-bind_ip = 127.0.0.1
+bind_ip = 0.0.0.0
 master_ip = 127.0.0.1
-master_port = 11001
+master_port = 10999
 cluster_key = dst

--- a/game_eggs/steamcmd_servers/dont_starve/server.master.ini
+++ b/game_eggs/steamcmd_servers/dont_starve/server.master.ini
@@ -2,7 +2,7 @@
 encode_user_path = true
 
 [NETWORK]
-server_port = 10999
+server_port = 11000
 
 [SHARD]
 is_master = true


### PR DESCRIPTION
# Description

**Changes:**
- Switched to using x64 server binaries to allow more RAM to be utilized if needed.
- Remove deprecated and unneeded launch parameters, as configs are already being modified to have correct values.
- Change Caves-shard id to 2, as it's the 2nd shard in the cluster.
- Bind cluster IP to 0.0.0.0 to allow incoming connections to it for proxying.
- Warn about using shard ports in the egg README, using these will prevent either shard from working properly.

Overall these changes fix #2035, with some additional cleanup of the egg.

## Checklist for all submissions

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:
