### PR TITLE
Specify TCP or UDP for the defaults

### DIFF
--- a/game_eggs/minecraft/crossplay/purpur-geysermc-floodgate/README.md
+++ b/game_eggs/minecraft/crossplay/purpur-geysermc-floodgate/README.md
@@ -11,7 +11,7 @@ Purpur-GeyserMC-Floodgate is a drop-in replacement for Paper servers designed fo
 
 ## Server Ports
 
-The minecraft server requires a single port for access (default 25565 TCP). GeyserMC requires an additional port (default 19132 UDP). Any other plugins you add may require extra ports to enabled for the server.
+The minecraft server requires a single port for access (default 25565). GeyserMC requires an additional port (default 19132). Any other plugins you add may require extra ports to enabled for the server.
 
 | Port     | default | Protocol |
 |----------|---------|----------|

--- a/game_eggs/minecraft/crossplay/purpur-geysermc-floodgate/README.md
+++ b/game_eggs/minecraft/crossplay/purpur-geysermc-floodgate/README.md
@@ -11,9 +11,9 @@ Purpur-GeyserMC-Floodgate is a drop-in replacement for Paper servers designed fo
 
 ## Server Ports
 
-The minecraft server requires a single port for access (default 25565). GeyserMC requires an additional port (default 19132). Any other plugins you add may require extra ports to enabled for the server.
+The minecraft server requires a single port for access (default 25565 TCP). GeyserMC requires an additional port (default 19132 UDP). Any other plugins you add may require extra ports to enabled for the server.
 
-| Port     | default |
-|----------|---------|
-| Java     | 25565   |
-| Bedrock  | 19132   |
+| Port     | default | Protocol |
+|----------|---------|----------|
+| Java     | 25565   |  TCP     |
+| Bedrock  | 19132   |  UDP     |


### PR DESCRIPTION
It should make it easier for the people who are newer to networking.

# Description

I just updated the Readme.MD file so it specified TCP or UDP for the default ports to make it easier for anyone unfamiliar with networking or the software involved.

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done. You can click preview to make the links appear clickable. -->

 *[ X] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
