### PR TITLE
Gitea - switched image to be ARM compatible

### DIFF
--- a/software/gitea/egg-gitea.json
+++ b/software/gitea/egg-gitea.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2023-01-23T18:11:52+01:00",
+    "exported_at": "2023-01-26T18:20:19+01:00",
     "name": "Gitea",
     "author": "mario.franze@gmail.com",
     "description": "Gitea is a community managed lightweight code hosting solution written in Go. It is published under the MIT license.",
@@ -23,7 +23,7 @@
     "scripts": {
         "installation": {
             "script": "## Gitea Installscript\r\n\r\n## Variables\r\nARCH=$([[ \"$(uname -m)\" == \"x86_64\" ]] && echo \"amd64\" || echo \"arm64\")\r\nLATEST=$(curl https:\/\/dl.gitea.io\/gitea\/version.json | echo $(jq -r \".latest.version\"))\r\n\r\n## update system\r\napt update\r\napt install -y --no-install-recommends jq curl\r\n\r\ncd \/mnt\/server\r\n\r\n## install gitea\r\nif [ -z \"${VERSION}\" ] || [ \"${VERSION}\" == \"latest\" ]; then\r\n    echo -e \"downloading Gitea $LATEST\"\r\n    curl -Lo gitea https:\/\/dl.gitea.io\/gitea\/${LATEST}\/gitea-${LATEST}-linux-${ARCH}\r\nelif [ \"${VERSION}\" == \"nightly\" ]; then\r\n    echo -e \"downloading Gitea nightly\"\r\n    curl -Lo gitea https:\/\/dl.gitea.io\/gitea\/main\/gitea-main-linux-${ARCH}\r\nelse\r\n    curl -Lo gitea https:\/\/dl.gitea.io\/gitea\/${VERSION}\/gitea-${VERSION}-linux-${ARCH}\r\n    echo -e \"downloading Gitea $VERSION\"\r\nfi\r\n\r\nchmod +x gitea\r\n\r\nmkdir -p custom\r\n\r\nif [ -f \"\/mnt\/server\/custom\/app.ini\" ]; then\r\n    echo \"config file exists\"\r\nelse\r\n    echo \"[server]\r\n    LOCAL_ROOT_URL = http:\/\/${SERVER_IP}:${SERVER_PORT}\/\r\n    DOMAIN           = ${SERVER_IP}\r\n    HTTP_PORT        = ${SERVER_PORT}\r\n    ROOT_URL         = http:\/\/${SERVER_IP}:${SERVER_PORT}\/\r\n    DISABLE_SSH      = ${DISABLE_SSH}\r\n    SSH_PORT         = ${SSH_PORT}\" > \/mnt\/server\/custom\/app.ini\r\nfi\r\n\r\necho -e \"-------------------------------------------------\"\r\necho -e \"Installation completed\"\r\necho -e \"-------------------------------------------------\"",
-            "container": "ghcr.io\/parkervcp\/installers:debian",
+            "container": "debian:bullseye-slim",
             "entrypoint": "bash"
         }
     },


### PR DESCRIPTION
# Description

I accidentally used the Debian Imstall image; this is not ARM compatible. Image has been updated to the official Bullseye image

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done. You can click preview to make the links appear clickable. -->

* [ ] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [ ] Have you tested and reviewed your changes with confidence that everything works?
* [ ] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

