### PR TITLE
add: server startup password as variable

### DIFF
--- a/voice_servers/teamspeak_ARM64/egg-teamspeak3-arm64-server.json
+++ b/voice_servers/teamspeak_ARM64/egg-teamspeak3-arm64-server.json
@@ -35,7 +35,7 @@
             "default_value": "changeme",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string|max:32",
+            "rules": "nullable|string|max:32",
             "field_type": "text"
         },
         {

--- a/voice_servers/teamspeak_ARM64/egg-teamspeak3-arm64-server.json
+++ b/voice_servers/teamspeak_ARM64/egg-teamspeak3-arm64-server.json
@@ -13,7 +13,7 @@
         "ghcr.io\/parkervcp\/yolks:box64": "ghcr.io\/parkervcp\/yolks:box64"
     },
     "file_denylist": [],
-    "startup": "box64 .\/ts3server default_voice_port={{SERVER_PORT}} query_port={{QUERY_PORT}} filetransfer_ip=0.0.0.0 filetransfer_port={{FILE_TRANSFER}} license_accepted=1",
+    "startup": "box64 .\/ts3server default_voice_port={{SERVER_PORT}} query_port={{QUERY_PORT}} filetransfer_ip=0.0.0.0 filetransfer_port={{FILE_TRANSFER}} serveradmin_password={{SERVERADMIN_PASSWORD}} license_accepted=1",
     "config": {
         "files": "{}",
         "startup": "{\r\n    \"done\": \"listening on 0.0.0.0:\"\r\n}",
@@ -28,6 +28,16 @@
         }
     },
     "variables": [
+        {
+            "name": "Server Query Admin Password",
+            "description": "The password for the server query admin user.",
+            "env_variable": "SERVERADMIN_PASSWORD",
+            "default_value": "changeme",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string|max:32",
+            "field_type": "text"
+        },
         {
             "name": "Server Version",
             "description": "The version of Teamspeak 3 to use when running the server.",

--- a/voice_servers/teamspeak_ARM64/egg-teamspeak3-arm64-server.json
+++ b/voice_servers/teamspeak_ARM64/egg-teamspeak3-arm64-server.json
@@ -32,7 +32,7 @@
             "name": "Server Query Admin Password",
             "description": "The password for the server query admin user.",
             "env_variable": "SERVERADMIN_PASSWORD",
-            "default_value": "changeme",
+            "default_value": "",
             "user_viewable": true,
             "user_editable": true,
             "rules": "nullable|string|max:32",


### PR DESCRIPTION
# Description

you can now start yout teamspeak server with a serverquery password defined under startup

## Checklist for all submissions

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you tested and reviewed your changes with confidence that everything works?
* [X] Did you branch your changes and PR from that branch and not from your master branch?