### PR TITLE
[rust-staging] fix: Install script ignoring Branch env variable

### DIFF
--- a/game_eggs/steamcmd_servers/rust/rust_staging/egg-rust-staging.json
+++ b/game_eggs/steamcmd_servers/rust/rust_staging/egg-rust-staging.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2022-11-26T11:35:36+01:00",
+    "exported_at": "2023-01-30T15:13:30+11:00",
     "name": "Rust Staging",
     "author": "root@smc.li",
     "description": "The only aim in Rust is to survive. To do this you will need to overcome struggles such as hunger, thirst and cold. Build a fire. Build a shelter. Kill animals for meat. Protect yourself from other players, and kill them for meat. Create alliances with other players and form a town. Do whatever it takes to survive.",
@@ -143,7 +143,7 @@
         {
             "name": "Branch",
             "description": "Select the branch to install, such as staging or workcart",
-            "env_variable": "BRANCH",
+            "env_variable": "SRCDS_BETAID",
             "default_value": "staging",
             "user_viewable": true,
             "user_editable": true,


### PR DESCRIPTION
# Description

<!-- Please explain what is being changed or added as a short overview for this PR. Also, link existing relevant issues if they exist with resolves # -->
Fixes startup script not respecting the branch startup option for the rust-staging egg

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [x] You verify that the start command applied does not use a shell script
  * [x] If some script is needed then it is part of a current yolk or a PR to add one
* [ ] The egg was exported from the panel