### PR TITLE
Added nodejs 18 support to the code server

### DIFF
--- a/software/code-server/egg-code--server.json
+++ b/software/code-server/egg-code--server.json
@@ -1,21 +1,21 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
-        "version": "PTDL_v1",
+        "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2022-05-05T19:37:05+02:00",
+    "exported_at": "2023-02-04T23:01:25+01:00",
     "name": "Code-Server",
     "author": "mario.franze@gmail.com",
     "description": "Run VS Code on any machine anywhere and access it in the browser.",
     "features": null,
-    "images": [
-        "ghcr.io\/parkervcp\/yolks:nodejs_18",
-        "ghcr.io\/parkervcp\/yolks:nodejs_17",
-        "ghcr.io\/parkervcp\/yolks:nodejs_16",
-        "ghcr.io\/parkervcp\/yolks:nodejs_14",
-        "ghcr.io\/parkervcp\/yolks:nodejs_12"
-    ],
+    "docker_images": {
+        "ghcr.io\/parkervcp\/yolks:nodejs_18": "ghcr.io\/parkervcp\/yolks:nodejs_18",
+        "ghcr.io\/parkervcp\/yolks:nodejs_17": "ghcr.io\/parkervcp\/yolks:nodejs_17",
+        "ghcr.io\/parkervcp\/yolks:nodejs_16": "ghcr.io\/parkervcp\/yolks:nodejs_16",
+        "ghcr.io\/parkervcp\/yolks:nodejs_14": "ghcr.io\/parkervcp\/yolks:nodejs_14",
+        "ghcr.io\/parkervcp\/yolks:nodejs_12": "ghcr.io\/parkervcp\/yolks:nodejs_12"
+    },
     "file_denylist": [],
     "startup": "sh .local\/lib\/code-server-{{VERSION}}\/bin\/code-server",
     "config": {
@@ -39,7 +39,8 @@
             "default_value": "changeme",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string|max:32"
+            "rules": "required|string|max:32",
+            "field_type": "text"
         },
         {
             "name": "Version",
@@ -48,7 +49,8 @@
             "default_value": "latest",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "string|max:20"
+            "rules": "string|max:20",
+            "field_type": "text"
         }
     ]
 }

--- a/software/code-server/egg-code--server.json
+++ b/software/code-server/egg-code--server.json
@@ -10,6 +10,7 @@
     "description": "Run VS Code on any machine anywhere and access it in the browser.",
     "features": null,
     "images": [
+        "ghcr.io\/parkervcp\/yolks:nodejs_18",
         "ghcr.io\/parkervcp\/yolks:nodejs_17",
         "ghcr.io\/parkervcp\/yolks:nodejs_16",
         "ghcr.io\/parkervcp\/yolks:nodejs_14",


### PR DESCRIPTION
# Description

The Code-server egg only supports node versions up to 17. I simply added 18.

## Checklist for all submissions

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:



* [x] You verify that the start command applied does not use a shell script
  * [x] If some script is needed then it is part of a current yolk or a PR to add one
* [x] The egg was exported from the panel

