### PR TITLE
Dart: add 2.18 and 2.19 image as an option

### DIFF
--- a/generic/dart/egg-dart-generic.json
+++ b/generic/dart/egg-dart-generic.json
@@ -4,13 +4,15 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2022-07-07T16:11:46-07:00",
+    "exported_at": "2023-02-24T17:58:34+01:00",
     "name": "dart generic",
     "author": "alden@knoban.com",
     "description": "A generic dart CLI egg.\r\n\r\nThis will clone a dart CLI application. it defaults to master if no branch is specified.\r\n\r\nInstalls the pubspec.yaml packages on run. If you set user_upload then I assume you know what you are doing.",
     "features": null,
     "docker_images": {
-        "ghcr.io/parkervcp/yolks:dart_2.17": "ghcr.io/parkervcp/yolks:dart_2.17"
+        "Dart_2.19": "ghcr.io\/parkervcp\/yolks:dart_2.19",
+        "Dart_2.18": "ghcr.io\/parkervcp\/yolks:dart_2.18",
+        "Dart_2.17": "ghcr.io\/parkervcp\/yolks:dart_2.17"
     },
     "file_denylist": [],
     "startup": "if [[ -d .git ]] && [[ {{AUTO_UPDATE}} == \"1\" ]]; then git pull; fi; dart pub get; dart run",


### PR DESCRIPTION
# Description

add dart 2.18 and 2.19 as an option for docker image

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [x] You verify that the start command applied does not use a shell script
  * [ ] If some script is needed then it is part of a current yolk or a PR to add one
* [x] The egg was exported from the panel
