### PR TITLE
Adding Elang25 and Elang26 support for MQRabbit

### DIFF
--- a/software/rabbitmq/README.md
+++ b/software/rabbitmq/README.md
@@ -12,6 +12,8 @@ When setting up a server, the latest RabbitMQ version will be used by default.
 With pretty new and old versions of RabbitMQ, you might have to adjust the used Erlang version.
 This can be archived by adjusting the version number of the used image (e. g. `ghcr.io/pterodactyl/yolks:erlang_22` instead of `ghcr.io/parkervcp/yolks:erlang_24`).
 
+The latest version as of now requires you to use atleast ghcr.io/pterodactyl/yolks:erlang_25
+
 ## Configuration
 
 Configuring RabbitMQ in Pterodactyl is only possible using the config files.

--- a/software/rabbitmq/egg-rabbit-m-q.json
+++ b/software/rabbitmq/egg-rabbit-m-q.json
@@ -10,6 +10,8 @@
     "description": "RabbitMQ is a feature rich, multi-protocol messaging broker.",
     "features": null,
     "images": [
+        "ghcr.io\/parkervcp\/yolks:erlang_26",
+        "ghcr.io\/parkervcp\/yolks:erlang_25",
         "ghcr.io\/parkervcp\/yolks:erlang_24",
         "ghcr.io\/parkervcp\/yolks:erlang_23",
         "ghcr.io\/parkervcp\/yolks:erlang_22"

--- a/software/rabbitmq/egg-rabbit-m-q.json
+++ b/software/rabbitmq/egg-rabbit-m-q.json
@@ -1,21 +1,21 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
-        "version": "PTDL_v1",
+        "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2021-08-02T15:24:45+02:00",
+    "exported_at": "2023-03-17T19:22:21+01:00",
     "name": "RabbitMQ",
     "author": "p.zarrad@outlook.de",
     "description": "RabbitMQ is a feature rich, multi-protocol messaging broker.",
     "features": null,
-    "images": [
-        "ghcr.io\/parkervcp\/yolks:erlang_26",
-        "ghcr.io\/parkervcp\/yolks:erlang_25",
-        "ghcr.io\/parkervcp\/yolks:erlang_24",
-        "ghcr.io\/parkervcp\/yolks:erlang_23",
-        "ghcr.io\/parkervcp\/yolks:erlang_22"
-    ],
+    "docker_images": {
+        "ghcr.io\/parkervcp\/yolks:erlang_26": "ghcr.io\/parkervcp\/yolks:erlang_26",
+        "ghcr.io\/parkervcp\/yolks:erlang_25": "ghcr.io\/parkervcp\/yolks:erlang_25",
+        "ghcr.io\/parkervcp\/yolks:erlang_24": "ghcr.io\/parkervcp\/yolks:erlang_24",
+        "ghcr.io\/parkervcp\/yolks:erlang_23": "ghcr.io\/parkervcp\/yolks:erlang_23",
+        "ghcr.io\/parkervcp\/yolks:erlang_22": "ghcr.io\/parkervcp\/yolks:erlang_22"
+    },
     "file_denylist": [],
     "startup": ".\/sbin\/rabbitmq-server",
     "config": {
@@ -39,7 +39,8 @@
             "default_value": "latest",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string|max:20"
+            "rules": "required|string|max:20",
+            "field_type": "text"
         }
     ]
 }


### PR DESCRIPTION
# Description

Added the yolks for Elang 25 and Elang 26. Also added a installation explanation that the latest version of RabbitMQ atleast requires elang25

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [ ] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?: It’s adding 2 lines to the current JSON. Not sure if a different branch is really needed.

<!-- If this is an egg update fill these out -->

* [x] You verify that the start command applied does not use a shell script
  * [ ] If some script is needed then it is part of a current yolk or a PR to add one
* [ ] The egg was exported from the panel