### PR TITLE
Core-Keeper: Updated startup check after server update

### DIFF
--- a/game_eggs/steamcmd_servers/core_keeper/egg-core-keeper.json
+++ b/game_eggs/steamcmd_servers/core_keeper/egg-core-keeper.json
@@ -18,7 +18,7 @@
     "startup": "export DISPLAY=:0; rm .\/GameID.txt .\/CoreKeeperServerLog.txt; touch .\/CoreKeeperServerLog.txt; xvfb-run -s \"-screen 0 {{DISPLAY_WIDTH}}x{{DISPLAY_HEIGHT}}x{{DISPLAY_DEPTH}} -ac -nolisten tcp -nolisten unix\" .\/CoreKeeperServer -logfile CoreKeeperServerLog.txt -world {{WORLD_INDEX}} -worldname \"{{WORLD_NAME}}\" -worldseed {{WORLD_SEED}} $([[ \"{{GAME_ID}}\" != \"\" ]] && echo -n \" -gameid {{GAME_ID}}\") -maxplayers {{MAX_PLAYERS}} -worldmode {{WORLD_MODE}} -port {{SERVER_PORT}} & CKPID=$!; tail -f CoreKeeperServerLog.txt & LOGPID=$!; trap \"kill ${CKPID}; wait ${CKPID}; kill ${LOGPID}; wait ${LOGPID}\" 15; wait $!",
     "config": {
         "files": "{}",
-        "startup": "{\r\n    \"done\": \"Started server process with pid\"\r\n}",
+        "startup": "{\r\n    \"done\": \"Started session\"\r\n}",
         "logs": "{}",
         "stop": "^C"
     },

--- a/game_eggs/steamcmd_servers/core_keeper/egg-core-keeper.json
+++ b/game_eggs/steamcmd_servers/core_keeper/egg-core-keeper.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2023-03-13T19:20:35+01:00",
+    "exported_at": "2023-03-18T23:18:52+01:00",
     "name": "Core Keeper",
     "author": "karsten@fiedleronline.net",
     "description": "Core Keeper is a survival sandbox game for single or multiplayers.\r\n\r\n--- Drawn towards a mysterious relic, you are an explorer who awakens in an ancient cavern of creatures, resources and trinkets. Trapped deep underground will your survival skills be up to the task? Mine relics and resources to build your base, craft new equipment, survive, and power up the Core. ---",


### PR DESCRIPTION
# Description

<!-- Please explain what is being changed or added as a short overview for this PR. Also, link existing relevant issues if they exist with resolves # -->

The server output is "Started session with Game ID..." after the dedicated server update. The check whether the server was started successfully has been adjusted accordingly.

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you tested and reviewed your changes with confidence that everything works?
* [X] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [X] You verify that the start command applied does not use a shell script
  * [ ] If some script is needed then it is part of a current yolk or a PR to add one
* [X] The egg was exported from the panel

<!-- You can erase the new egg submission template if you're not adding a completely new egg -->
