### PR TITLE
Make python invocation work with bash exec

### DIFF
--- a/generic/python/egg-python-generic.json
+++ b/generic/python/egg-python-generic.json
@@ -18,7 +18,7 @@
         "Python 2.7": "ghcr.io\/parkervcp\/yolks:python_2.7"
     },
     "file_denylist": [],
-    "startup": "if [[ -d .git ]] && [[ \"{{AUTO_UPDATE}}\" == \"1\" ]]; then git pull; fi; if [[ ! -z \"{{PY_PACKAGES}}\" ]]; then pip install -U --prefix .local {{PY_PACKAGES}}; fi; if [[ -f \/home\/container\/${REQUIREMENTS_FILE} ]]; then pip install -U --prefix .local -r \"${REQUIREMENTS_FILE}\"; fi; exec \/usr\/local\/bin\/python \"\/home\/container\/{{PY_FILE}}\@",
+    "startup": "if [[ -d .git ]] && [[ \"{{AUTO_UPDATE}}\" == \"1\" ]]; then git pull; fi; if [[ ! -z \"{{PY_PACKAGES}}\" ]]; then pip install -U --prefix .local {{PY_PACKAGES}}; fi; if [[ -f \/home\/container\/${REQUIREMENTS_FILE} ]]; then pip install -U --prefix .local -r \"${REQUIREMENTS_FILE}\"; fi; exec \/usr\/local\/bin\/python \"\/home\/container\/${PY_FILE}\"",
     "config": {
         "files": "{}",
         "startup": "{\r\n    \"done\": \"change this part\"\r\n}",

--- a/generic/python/egg-python-generic.json
+++ b/generic/python/egg-python-generic.json
@@ -18,7 +18,7 @@
         "Python 2.7": "ghcr.io\/parkervcp\/yolks:python_2.7"
     },
     "file_denylist": [],
-    "startup": "if [[ -d .git ]] && [[ \"{{AUTO_UPDATE}}\" == \"1\" ]]; then git pull; fi; if [[ ! -z \"{{PY_PACKAGES}}\" ]]; then pip install -U --prefix .local {{PY_PACKAGES}}; fi; if [[ -f \/home\/container\/${REQUIREMENTS_FILE} ]]; then pip install -U --prefix .local -r ${REQUIREMENTS_FILE}; fi; \/usr\/local\/bin\/python \/home\/container\/{{PY_FILE}}",
+    "startup": "if [[ -d .git ]] && [[ \"{{AUTO_UPDATE}}\" == \"1\" ]]; then git pull; fi; if [[ ! -z \"{{PY_PACKAGES}}\" ]]; then pip install -U --prefix .local {{PY_PACKAGES}}; fi; if [[ -f \/home\/container\/${REQUIREMENTS_FILE} ]]; then pip install -U --prefix .local -r \"${REQUIREMENTS_FILE}\"; fi; exec \/usr\/local\/bin\/python \"\/home\/container\/{{PY_FILE}}\@",
     "config": {
         "files": "{}",
         "startup": "{\r\n    \"done\": \"change this part\"\r\n}",


### PR DESCRIPTION
Currently, when using this egg, the "Stop" button in the panel will absolutely not work. This is because the stop button sends a SIGTERM signal to the Bash process, and the Bash process will ignore the SIGTERM without propagating it to the Python process.

By adding `exec`, the Bash process will be completely replaced by the Python process, so the SIGTERM will reach the Python process and it will terminate normally.

P.S. I just had a situation where the panel registered the server as completely shut down but the server was still up and running. Please fix it

# Description

<!-- Please explain what is being changed or added as a short overview for this PR. Also, link existing relevant issues if they exist with resolves # -->

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [ ] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [x] You verify that the start command applied does not use a shell script
  * [ ] If some script is needed then it is part of a current yolk or a PR to add one
* [ ] The egg was exported from the panel

<!-- You can erase the new egg submission template if you're not adding a completely new egg -->
