### PR TITLE
Fix typo in egg-squad.json

### DIFF
--- a/game_eggs/steamcmd_servers/squad/egg-squad.json
+++ b/game_eggs/steamcmd_servers/squad/egg-squad.json
@@ -101,7 +101,7 @@
             "field_type": "text"
         },
         {
-            "name": "Reserved Slows",
+            "name": "Reserved Slots",
             "description": "The number of reserved slots for admins \/ mods",
             "env_variable": "reservedslots",
             "default_value": "0",

--- a/game_eggs/steamcmd_servers/squad/egg-squad.json
+++ b/game_eggs/steamcmd_servers/squad/egg-squad.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2023-01-13T11:04:16+01:00",
+    "exported_at": "2023-04-11T11:41:50-06:00",
     "name": "Squad",
     "author": "brycea@terrahost.cloud",
     "description": "Squad is a 50 vs 50 multiplayer first-person shooter that aims to capture combat realism through communication and teamplay. Major features include vehicle-based combined arms gameplay, large scale environments, base building, and integrated positional VoIP for proximity talking & radio.",


### PR DESCRIPTION
# Description

There is a typo in the squad configuration which asks for "Reserved Slows" this is meant to say "Reserved Slots" and is even referenced as that in the description.

I tested this by changing the variable name in the panel, exporting, and comparing the diff against master. The only differences were the exported_at field, and the typo fix.

If there's more testing you'd like me to do, just let me know :) Also if a PR like this is unwelcome, feel free to just close it.

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you tested and reviewed your changes with confidence that everything works?
* [X] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [ ] You verify that the start command applied does not use a shell script
  * [ ] If some script is needed then it is part of a current yolk or a PR to add one
* [X] The egg was exported from the panel