### PR TITLE
Add more languages to the Start Configuration for PMMP and Nukkit

### DIFF
--- a/game_eggs/minecraft/bedrock/nukkit/egg-nukkit.json
+++ b/game_eggs/minecraft/bedrock/nukkit/egg-nukkit.json
@@ -1,26 +1,26 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
-        "version": "PTDL_v1",
+        "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2021-12-16T13:31:45-05:00",
+    "exported_at": "2023-04-29T11:05:36+01:00",
     "name": "Nukkit",
     "author": "parker@parkervcp.com",
     "description": "Nukkit is a Nuclear-Powered Server Software For Minecraft: Pocket Edition\r\n\r\nhttps:\/\/cloudburstmc.org",
     "features": null,
-    "images": [
-        "quay.io\/pterodactyl\/core:java-glibc",
-        "ghcr.io\/pterodactyl\/yolks:java_11",
-        "ghcr.io\/pterodactyl\/yolks:java_16",
-        "ghcr.io\/pterodactyl\/yolks:java_8",
-        "ghcr.io\/pterodactyl\/yolks:java_17"
-    ],
+    "docker_images": {
+        "quay.io\/pterodactyl\/core:java-glibc": "quay.io\/pterodactyl\/core:java-glibc",
+        "ghcr.io\/pterodactyl\/yolks:java_11": "ghcr.io\/pterodactyl\/yolks:java_11",
+        "ghcr.io\/pterodactyl\/yolks:java_16": "ghcr.io\/pterodactyl\/yolks:java_16",
+        "ghcr.io\/pterodactyl\/yolks:java_8": "ghcr.io\/pterodactyl\/yolks:java_8",
+        "ghcr.io\/pterodactyl\/yolks:java_17": "ghcr.io\/pterodactyl\/yolks:java_17"
+    },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",
     "config": {
         "files": "{\r\n    \"server.properties\": {\r\n        \"parser\": \"properties\",\r\n        \"find\": {\r\n            \"server-ip\": \"0.0.0.0\",\r\n            \"enable-query\": \"true\",\r\n            \"server-port\": \"{{server.build.default.port}}\",\r\n            \"query.port\": \"{{server.build.default.port}}\"\r\n        }\r\n    }\r\n}",
-        "startup": "{\r\n    \"done\": \")! For help, type \"\r\n}",
+        "startup": "{\r\n    \"done\": [\r\n        \")! For help, type \",\r\n        \")! Para ver a ajuda, escreva\",\r\n        \")\uff01\u5982\u9700\u5e2e\u52a9\uff0c\u8bf7\u8f93\u5165\",\r\n        \")\uff01\u5982\u9700\u5e6b\u52a9\uff0c\u8acb\u8f38\u5165\",\r\n        \")! Pro pomoc, napis\",\r\n        \")! F\u00fcr Hilfe, tippe\",\r\n        \")! Kirjoita\",\r\n        \")\\uFF01 \\\"help\\\"\\u307E\\u305F\\u306F\\\"?\\\"\\u3067\\u30D8\\u30EB\\u30D7\\u3092\\u8868\\u793A\",\r\n        \")! \ub3c4\uc6c0\ub9d0\uc744 \ucc38\uc870\ud558\uc2dc\ub824\uba74\",\r\n        \")! Jeigu reikia pagalbos, ra\u0161ykite\",\r\n        \")! Aby uzyskac pomoc wpisz\",\r\n        \")! \u0414\u043b\u044f \u0441\u043f\u0440\u0430\u0432\u043a\u0438 \u0432\u0432\u0435\u0434\u0438\u0442\u0435\",\r\n        \")! Escribe\",\r\n        \")! \u0414\u043b\u044f \u0434\u043e\u043f\u043e\u043c\u043e\u0433\u0438, \u043d\u0430\u0431\u0435\u0440\u0456\u0442\u044c\"\r\n    ]\r\n}",
         "logs": "{\r\n    \"custom\": false,\r\n    \"location\": \"logs\/latest.log\"\r\n}",
         "stop": "stop"
     },
@@ -39,7 +39,8 @@
             "default_value": "server.jar",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|regex:\/^([\\w\\d._-]+)(\\.jar)$\/"
+            "rules": "required|regex:\/^([\\w\\d._-]+)(\\.jar)$\/",
+            "field_type": "text"
         },
         {
             "name": "Download Path",
@@ -48,7 +49,8 @@
             "default_value": "",
             "user_viewable": false,
             "user_editable": false,
-            "rules": "nullable|string"
+            "rules": "nullable|string",
+            "field_type": "text"
         },
         {
             "name": "nukkit version",
@@ -57,7 +59,8 @@
             "default_value": "latest",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string|max:20"
+            "rules": "required|string|max:20",
+            "field_type": "text"
         }
     ]
 }

--- a/game_eggs/minecraft/bedrock/pocketmine_mp/egg-pocketmine-m-p.json
+++ b/game_eggs/minecraft/bedrock/pocketmine_mp/egg-pocketmine-m-p.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2023-02-12T02:53:07-05:00",
+    "exported_at": "2023-04-29T11:05:30+01:00",
     "name": "PocketmineMP",
     "author": "info@swisscrafting.ch",
     "description": "Pocketmine Egg\r\nby onekintaro from swisscrafting.ch\r\nwith the nice help from #eggs Channel on Pterodactyl-Discord :)",
@@ -16,7 +16,7 @@
     "startup": ".\/bin\/php7\/bin\/php .\/PocketMine-MP.phar --no-wizard --disable-ansi",
     "config": {
         "files": "{\r\n    \"server.properties\": {\r\n        \"parser\": \"properties\",\r\n        \"find\": {\r\n            \"server-ip\": \"0.0.0.0\",\r\n            \"enable-query\": \"true\",\r\n            \"server-port\": \"{{server.build.default.port}}\",\r\n            \"query.port\": \"{{server.build.default.port}}\"\r\n        }\r\n    }\r\n}",
-        "startup": "{\r\n    \"done\": \")! For help, type \"\r\n}",
+        "startup": "{\r\n    \"done\": [\r\n        \")! For help, type \",\r\n        \")! Escribe \",\r\n        \")! F\u00fcr Hilfe\",\r\n        \")! Pour afficher l\",\r\n        \")! \u30d8\u30eb\u30d7\u3092\u8868\u793a\u3059\u308b\u306b\u306f\",\r\n        \")! \ub3c4\uc6c0\ub9d0\uc744 \ubcf4\ub824\uba74\",\r\n        \")! Priek\u0161 pal\u012bdz\u012bbas\",\r\n        \")! Voor hulp, typ\",\r\n        \")! \u0414\u043b\u044f \u0441\u043f\u0440\u0430\u0432\u043a\u0438, \u0432\u0432\u0435\u0434\u0438\u0442\u0435\",\r\n        \")! Escribe \",\r\n        \")! \u0110\u1ec3 \u0111\u01b0\u1ee3c tr\u1ee3 gi\u00fap, h\u00e3y nh\u1eadp\"\r\n    ]\r\n}",
         "logs": "{}",
         "stop": "stop"
     },


### PR DESCRIPTION
# Description

Pocketmine and Nukkit allow for changing languages that the console uses, which changes the message that Start Configuration looks for to set the server state to running. I went through all the pocketmine and nukkit translations (https://github.com/pmmp/Language, https://github.com/CloudburstMC/Languages/) and copied the pocketmine.server.startFinished and nukkit.server.startFinished string respectively for each language that had translations for those events.

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [ ] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?: minor change

<!-- If this is an egg update fill these out -->

* [x] You verify that the start command applied does not use a shell script
  * [x] If some script is needed then it is part of a current yolk or a PR to add one
* [x] The egg was exported from the panel
