### PR TITLE
Fix typo in README.md (LanguageTool egg)

### DIFF
--- a/software/languagetool/README.md
+++ b/software/languagetool/README.md
@@ -4,6 +4,6 @@ LanguageTool is an Open Source proofreading software for English, French, German
 
 View https://languagetool.org for more information.
 
-Requires one prt for comunication.
+Requires one port for comunication.
 
 Try `addr:port/v2/check?language=en-US&text=this+is+a+test` to test


### PR DESCRIPTION
# Description

Fixing typo in README for LanguageTool egg ("prt" to "port")

## Checklist for all submissions

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you tested and reviewed your changes with confidence that everything works?
* [X] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?: N/A