### PR TITLE
Update frozen-flame

### DIFF
--- a/game_eggs/steamcmd_servers/frozen_flame/README.md
+++ b/game_eggs/steamcmd_servers/frozen_flame/README.md
@@ -8,8 +8,8 @@ Frozen Flame is a Survival RPG set in the vast world of Arсana, an ancient land
 | Port      | default |
 |-----------|---------|
 | Game      | 7777    |
-| Query     | 27015   |
-| RCON      | 25575   |
+| Query     | 25575   |
+| RCON      | 27015   |
 
 ## Server configuration
 The documentation can be found here: [Dedicated server documentation](https://github.com/DreamsideInteractive/FrozenFlameServer)

--- a/game_eggs/steamcmd_servers/frozen_flame/egg-frozen-flame.json
+++ b/game_eggs/steamcmd_servers/frozen_flame/egg-frozen-flame.json
@@ -4,25 +4,25 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2023-02-03T14:32:26+08:00",
+    "exported_at": "2023-05-07T12:10:34+02:00",
     "name": "Frozen Flame",
     "author": "theblitzbat@gmail.com",
     "description": "Frozen Flame Dedicated Server",
     "features": null,
     "docker_images": {
-        "ghcr.io\/parkervcp\/games:source": "ghcr.io\/parkervcp\/games:source"
+        "ghcr.io\/parkervcp\/steamcmd:debian": "ghcr.io\/parkervcp\/steamcmd:debian"
     },
     "file_denylist": [],
-    "startup": ".\/FrozenFlame\/Binaries\/Linux\/FrozenFlameServer -log -MetaGameServerName={{SERVER_NAME}} -port {{SERVER_PORT}} -queryPort {{QUERY_PORT}}",
+    "startup": ".\/FrozenFlame\/Binaries\/Linux\/FrozenFlameServer-Linux-Shipping -log -MetaGameServerName={{SERVER_NAME}} -port {{SERVER_PORT}} -queryPort {{QUERY_PORT}} -RconPort={{RCON_PORT}} -RconPassword={{RCON_PASSWORD}}",
     "config": {
         "files": "{\r\n    \"FrozenFlame\/Saved\/Config\/LinuxServer\/Game.ini\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"MaxPlayers\": \"MaxPlayers={{server.build.env.MAX_PLAYERS}}\",\r\n            \"ServerPassword\": \"ServerPassword=\\\"{{server.build.env.SERVER_PASSWORD}}\\\"\"\r\n        }\r\n    }\r\n}",
         "startup": "{\r\n    \"done\": \"LogWorld: Bringing up level for play took\"\r\n}",
         "logs": "{}",
-        "stop": "^C"
+        "stop": "^^C"
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/bash\r\n# steamcmd Base Installation Script\r\n\r\n## just in case someone removed the defaults.\r\n\r\nSTEAM_USER=anonymous\r\nSTEAM_PASS=\"\"\r\nSTEAM_AUTH=\"\"\r\n\r\n\r\n## download and install steamcmd\r\ncd \/tmp\r\nmkdir -p \/mnt\/server\/steamcmd\r\ncurl -sSL -o steamcmd.tar.gz https:\/\/steamcdn-a.akamaihd.net\/client\/installer\/steamcmd_linux.tar.gz\r\ntar -xzvf steamcmd.tar.gz -C \/mnt\/server\/steamcmd\r\n\r\nmkdir -p \/mnt\/server\/Engine\/Binaries\/ThirdParty\/SteamCMD\/Linux\r\ntar -xzvf steamcmd.tar.gz -C \/mnt\/server\/Engine\/Binaries\/ThirdParty\/SteamCMD\/Linux\r\nmkdir -p \/mnt\/server\/steamapps # Fix steamcmd disk write error when this folder is missing\r\ncd \/mnt\/server\/steamcmd\r\n\r\n# SteamCMD fails otherwise for some reason, even running as root.\r\n# This is changed at the end of the install process anyways.\r\nchown -R root:root \/mnt\r\nexport HOME=\/mnt\/server\r\n\r\n## install game using steamcmd\r\n.\/steamcmd.sh +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} +force_install_dir \/mnt\/server +app_update ${SRCDS_APPID} ${EXTRA_FLAGS} +quit\r\n\r\n## set up 32 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk32\r\ncp -v linux32\/steamclient.so ..\/.steam\/sdk32\/steamclient.so\r\n\r\n## set up 64 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk64\r\ncp -v linux64\/steamclient.so ..\/.steam\/sdk64\/steamclient.so\r\n\r\nmkdir -p \/mnt\/server\/FrozenFlame\/Saved\/Config\/LinuxServer\r\n\r\ncd \/mnt\/server\/FrozenFlame\/Saved\/Config\/LinuxServer\r\n\r\ncat > Game.ini << EOF\r\n[\/Script\/Engine.GameSession]\r\nMaxPlayers=${MAX_PLAYERS}\r\n\r\n[\/Script\/FrozenFlame.FGameSession]\r\nServerPassword=\"${SERVER_PASSWORD}\"\r\n\r\n[\/Script\/FrozenFlame.GameBalance]\r\n\r\n# Enable PVP for non-friends\r\nbFreePVP=True\r\n\r\n# How long a day lasts\r\nDurationOfDay=3600\r\n\r\n\r\n# Health after death\r\nHealthAfterRespawn=0.5\r\n\r\n# Restore health on level up\r\nbRestoreHealthOnLevelUp=True\r\n\r\n# Stamina cost at jumping\r\nJumpStaminaCost=6\r\n\r\n# Stamina cost at sprinting\r\nSprintStaminaCost=1\r\n\r\n# Loss of armor durability after death\r\nArmorDurabilityReducementAfterDeath=25\r\n\r\n# Weapon durability loss speed\r\nDefaultWeaponDurabilityCost=0.5\r\n\r\n\r\n# Allow to teleport with overweight\r\nbIsAllowedToTeleportWithOverweight=False\r\n\r\n# Allow to fly with overweight\r\nbIsAllowedToGlideWithOverweight=False\r\n\r\n\r\n# Drop of items after level X\r\nMinimalLevelToDropItemAfterDeath=2147483647\r\n\r\n# Drop equipped items after death\r\nbDropEquippedItems=False\r\n\r\n# Drop equipable items after death\r\nbDropEquipableItems=False\r\n\r\n# Drop food on death\r\nbDropFoodItems=False\r\n\r\n\r\n#Flame rate from everything\r\nFlameRate=1\r\n\r\n#Player damage multiplier\r\nPlayerDamageMultiplier=1\r\n\r\n#Monsters health multiplier\r\nMonstersHealthMultiplier=1\r\n\r\n#Monsters damage multiplier\r\nMonstersDamageMultiplier=1\r\n\r\n\r\n\r\n#Bulding without material costs\r\nbNoModuleCost=False\r\n\r\n#Building without restrictions\r\nbLimitlessSupport=False\r\n\r\n#Bulding without decay\r\nbInvulnerableModules=False\r\n\r\n\r\n[\/Script\/FrozenFlame.DecaySubsystemSettings]\r\n#A minimum durability that keeps after weather decay system damage\r\nMinDurability=0.300000\r\nEOF\r\n\r\n\r\necho \"-----------------------------------------\"\r\necho \"Installation completed...\"\r\necho \"-----------------------------------------\"",
+            "script": "!\/bin\/bash\r\n# steamcmd Base Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\n# Image to install with is 'ghcr.io\/parkervcp\/installers:debian'\r\n\r\n\r\n## just in case someone removed the defaults.\r\nif [[ \"${STEAM_USER}\" == \"\" ]] || [[ \"${STEAM_PASS}\" == \"\" ]]; then\r\n    echo -e \"steam user is not set.\\n\"\r\n    echo -e \"Using anonymous user.\\n\"\r\n    STEAM_USER=anonymous\r\n    STEAM_PASS=\"\"\r\n    STEAM_AUTH=\"\"\r\nelse\r\n    echo -e \"user set to ${STEAM_USER}\"\r\nfi\r\n\r\n## download and install steamcmd\r\ncd \/tmp\r\nmkdir -p \/mnt\/server\/steamcmd\r\ncurl -sSL -o steamcmd.tar.gz https:\/\/steamcdn-a.akamaihd.net\/client\/installer\/steamcmd_linux.tar.gz\r\ntar -xzvf steamcmd.tar.gz -C \/mnt\/server\/steamcmd\r\nmkdir -p \/mnt\/server\/steamapps # Fix steamcmd disk write error when this folder is missing\r\ncd \/mnt\/server\/steamcmd\r\n\r\n# SteamCMD fails otherwise for some reason, even running as root.\r\n# This is changed at the end of the install process anyways.\r\nchown -R root:root \/mnt\r\nexport HOME=\/mnt\/server\r\n\r\n## install game using steamcmd\r\n.\/steamcmd.sh +force_install_dir \/mnt\/server +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} $( [[ \"${WINDOWS_INSTALL}\" == \"1\" ]] && printf %s '+@sSteamCmdForcePlatformType windows' ) +app_update ${SRCDS_APPID} $( [[ -z ${SRCDS_BETAID} ]] || printf %s \"-beta ${SRCDS_BETAID}\" ) $( [[ -z ${SRCDS_BETAPASS} ]] || printf %s \"-betapassword ${SRCDS_BETAPASS}\" ) ${INSTALL_FLAGS} validate +quit ## other flags may be needed depending on install. looking at you cs 1.6\r\n\r\n## set up 32 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk32\r\ncp -v linux32\/steamclient.so ..\/.steam\/sdk32\/steamclient.so\r\n\r\n## set up 64 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk64\r\ncp -v linux64\/steamclient.so ..\/.steam\/sdk64\/steamclient.so\r\n\r\n## add below your custom commands if needed\r\n\r\nmkdir -p \/mnt\/server\/FrozenFlame\/Saved\/Config\/LinuxServer\r\n\r\ncd \/mnt\/server\/FrozenFlame\/Saved\/Config\/LinuxServer\r\n\r\nFILE=\/mnt\/server\/FrozenFlame\/Saved\/Config\/LinuxServer\/Game.ini\r\nif [ -f \"$FILE\" ]; then\r\n    echo \"Config file already exits. updating.\"\r\n    mv Game.ini Game.ini.back\r\n    curl -sSL o Game.ini https:\/\/raw.githubusercontent.com\/DreamsideInteractive\/FrozenFlameServer\/main\/Game.ini\r\nelse \r\n    echo \"Downloading a config file\"\r\n    curl -sSL -o Game.ini https:\/\/raw.githubusercontent.com\/DreamsideInteractive\/FrozenFlameServer\/main\/Game.ini\r\nfi\r\n\r\n\r\necho \"-----------------------------------------\"\r\necho \"Installation completed...\"\r\necho \"-----------------------------------------\"",
             "container": "ghcr.io\/parkervcp\/installers:debian",
             "entrypoint": "bash"
         }
@@ -59,16 +59,6 @@
             "field_type": "text"
         },
         {
-            "name": "Additional Arguments",
-            "description": "Specify additional launch parameters such as -crossplay. You must include a dash - and separate each parameter with space: -crossplay -exclusivejoin",
-            "env_variable": "ARGS",
-            "default_value": "",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": "nullable|string",
-            "field_type": "text"
-        },
-        {
             "name": "Server Name",
             "description": "The server name",
             "env_variable": "SERVER_NAME",
@@ -96,6 +86,26 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "boolean",
+            "field_type": "text"
+        },
+        {
+            "name": "Rcon Port",
+            "description": "",
+            "env_variable": "RCON_PORT",
+            "default_value": "27015",
+            "user_viewable": true,
+            "user_editable": false,
+            "rules": "required|string|",
+            "field_type": "text"
+        },
+        {
+            "name": "Rcon password",
+            "description": "",
+            "env_variable": "RCON_PASSWORD",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string|max:128",
             "field_type": "text"
         }
     ]

--- a/game_eggs/steamcmd_servers/frozen_flame/egg-frozen-flame.json
+++ b/game_eggs/steamcmd_servers/frozen_flame/egg-frozen-flame.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2023-05-07T12:10:34+02:00",
+    "exported_at": "2023-05-07T19:05:11+02:00",
     "name": "Frozen Flame",
     "author": "theblitzbat@gmail.com",
     "description": "Frozen Flame Dedicated Server",
@@ -13,7 +13,7 @@
         "ghcr.io\/parkervcp\/steamcmd:debian": "ghcr.io\/parkervcp\/steamcmd:debian"
     },
     "file_denylist": [],
-    "startup": ".\/FrozenFlame\/Binaries\/Linux\/FrozenFlameServer-Linux-Shipping -log -MetaGameServerName={{SERVER_NAME}} -port {{SERVER_PORT}} -queryPort {{QUERY_PORT}} -RconPort={{RCON_PORT}} -RconPassword={{RCON_PASSWORD}}",
+    "startup": ".\/FrozenFlame\/Binaries\/Linux\/FrozenFlameServer-Linux-Shipping -log -MetaGameServerName=\"{{SERVER_NAME}}\" -port={{SERVER_PORT}} -queryPort={{QUERY_PORT}} -RconPort={{RCON_PORT}} -RconPassword=\"{{RCON_PASSWORD}}\"",
     "config": {
         "files": "{\r\n    \"FrozenFlame\/Saved\/Config\/LinuxServer\/Game.ini\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"MaxPlayers\": \"MaxPlayers={{server.build.env.MAX_PLAYERS}}\",\r\n            \"ServerPassword\": \"ServerPassword=\\\"{{server.build.env.SERVER_PASSWORD}}\\\"\"\r\n        }\r\n    }\r\n}",
         "startup": "{\r\n    \"done\": \"LogWorld: Bringing up level for play took\"\r\n}",
@@ -52,7 +52,7 @@
             "name": "Query Port",
             "description": "The query port.",
             "env_variable": "QUERY_PORT",
-            "default_value": "27015",
+            "default_value": "25575",
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|integer|between:1024,65536",


### PR DESCRIPTION
# Description

- update startup cmd to add the rcon port and rcon password
- update the install script to the full steamcmd one
- update the install script to download the Game.ini and not echo the file as the file changed recently
- change to the steamcmd image as this is not a source egg
- update the stop cmd as else the server will not even atempt to stop
- redo the startup as the binary name changed

~~Please wait before merging this as I saw someone in the discord complain it hard binds to port 7777. I do not own this game so I can not test it so Please wait for that~~

I found what was wrong. there was a = missing in the startup see: https://github.com/parkervcp/eggs/pull/2251/commits/3c11c3a40bc00a22a8d51a38b52ab8441cf90a6c
I found it here: https://github.com/DreamsideInteractive/FrozenFlameServer/tree/main#launcher--create-a-bat--or-sh-file-with-the-following-contents-to-launch-you-server

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [x] You verify that the start command applied does not use a shell script
  * [ ] If some script is needed then it is part of a current yolk or a PR to add one
* [x] The egg was exported from the panel
