### PR TITLE
Update velocity egg

### DIFF
--- a/game_eggs/minecraft/proxy/java/velocity/egg-velocity.json
+++ b/game_eggs/minecraft/proxy/java/velocity/egg-velocity.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2023-04-03T16:55:25+02:00",
+    "exported_at": "2023-08-05T03:24:56+01:00",
     "name": "Velocity",
     "author": "parker@parkervcp.com",
     "description": "Velocity is a Minecraft server proxy with unparalleled server support, scalability, and flexibility.",
@@ -37,7 +37,7 @@
     "variables": [
         {
             "name": "Velocity Version",
-            "description": "The Velocity Proxy version to download.\r\n\r\nSet to 'latest ' the download the last stable build.\r\nSet to '1.1.x-SNAPSHOT' to get the latest dev build.",
+            "description": "The Velocity Proxy version to download.\r\n\r\nSet to 'latest ' the download the last stable build.",
             "env_variable": "VELOCITY_VERSION",
             "default_value": "latest",
             "user_viewable": true,

--- a/game_eggs/minecraft/proxy/java/velocity/velocity.toml
+++ b/game_eggs/minecraft/proxy/java/velocity/velocity.toml
@@ -1,12 +1,12 @@
 # Config version. Do not change this
-config-version = "2.5"
+config-version = "2.6"
 
 # What port should the proxy be bound to? By default, we'll bind to all addresses on port 25577.
 bind = "0.0.0.0:25577"
 
 # What should be the MOTD? This gets displayed when the player adds your server to
-# their server list. Legacy color codes and JSON are accepted.
-motd = "&#09add3A Velocity Server"
+# their server list. Only MiniMessage format is accepted.
+motd = "<#09add3>A Velocity Server"
 
 # What should we display for the maximum number of players? (Velocity does not support a cap
 # on the number of players online.)
@@ -34,7 +34,7 @@ prevent-client-proxy-connections = false
 #                  unable to implement network level firewalling (on a shared host).
 # - "modern":      Forward player IPs and UUIDs as part of the login process using
 #                  Velocity's native forwarding. Only applicable for Minecraft 1.13 or higher.
-player-info-forwarding-mode = "legacy"
+player-info-forwarding-mode = "NONE"
 
 # If you are using modern or BungeeGuard IP forwarding, configure a file that contains a unique secret here.
 # The file is expected to be UTF-8 encoded and not empty.
@@ -42,7 +42,7 @@ forwarding-secret-file = "forwarding.secret"
 
 # Announce whether or not your server supports Forge. If you run a modded server, we
 # suggest turning this on.
-#
+# 
 # If your network runs one modpack consistently, consider using ping-passthrough = "mods"
 # instead for a nicer display in the server list.
 announce-forge = false
@@ -72,25 +72,25 @@ enable-player-address-logging = true
 [servers]
 # Configure your servers here. Each key represents the server's name, and the value
 # represents the IP address of the server to connect to.
-lobby = "127.0.0.1:30066"
-factions = "127.0.0.1:30067"
-minigames = "127.0.0.1:30068"
+lobby = "172.18.0.1:30066"
+factions = "172.18.0.1:30067"
+minigames = "172.18.0.1:30068"
 
 # In what order we should try servers when a player logs in or is kicked from a server.
 try = [
-  "lobby"
+    "lobby"
 ]
 
 [forced-hosts]
 # Configure your forced hosts here.
 "lobby.example.com" = [
-  "lobby"
+    "lobby"
 ]
 "factions.example.com" = [
-  "factions"
+    "factions"
 ]
 "minigames.example.com" = [
-  "minigames"
+    "minigames"
 ]
 
 [advanced]

--- a/game_eggs/minecraft/proxy/java/velocity/velocity.toml
+++ b/game_eggs/minecraft/proxy/java/velocity/velocity.toml
@@ -72,9 +72,9 @@ enable-player-address-logging = true
 [servers]
 # Configure your servers here. Each key represents the server's name, and the value
 # represents the IP address of the server to connect to.
-lobby = "127.0.0.1:30066"
-factions = "127.0.0.1:30067"
-minigames = "127.0.0.1:30068"
+lobby = "172.18.0.1:30066"
+factions = "172.18.0.1:30067"
+minigames = "172.18.0.1:30068"
 
 # In what order we should try servers when a player logs in or is kicked from a server.
 try = [

--- a/game_eggs/minecraft/proxy/java/velocity/velocity.toml
+++ b/game_eggs/minecraft/proxy/java/velocity/velocity.toml
@@ -72,9 +72,9 @@ enable-player-address-logging = true
 [servers]
 # Configure your servers here. Each key represents the server's name, and the value
 # represents the IP address of the server to connect to.
-lobby = "172.18.0.1:30066"
-factions = "172.18.0.1:30067"
-minigames = "172.18.0.1:30068"
+lobby = "127.0.0.1:30066"
+factions = "127.0.0.1:30067"
+minigames = "127.0.0.1:30068"
 
 # In what order we should try servers when a player logs in or is kicked from a server.
 try = [


### PR DESCRIPTION
# Description

<!-- Please explain what is being changed or added as a short overview for this PR. Also, link existing relevant issues if they exist with resolves # -->

- Updates velocity.toml to the latest version, and changes any 127.0.0.1 entries to 172.18.0.1 (The default IP for pterodactyl0)

- Removes some text in the "Velocity Version Variable" referring to '1.1.x' as the latest dev version, as since Velocity merged into PaperMC the latest dev build is the same as the latest version

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [x] You verify that the start command applied does not use a shell script
  * [x] If some script is needed then it is part of a current yolk or a PR to add one
* [x] The egg was exported from the panel