### PR TITLE
Update sinusbot

### DIFF
--- a/bots/discord/sinusbot/egg-sinusbot.json
+++ b/bots/discord/sinusbot/egg-sinusbot.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2022-11-04T12:46:17+01:00",
+    "exported_at": "2023-08-14T15:15:05+02:00",
     "name": "Sinusbot",
     "author": "support@pterodactyl.io",
     "description": "Musicbot for Discord and Teamspeak.",
@@ -22,7 +22,7 @@
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/bash\r\n# Sinusbot Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\napt -y update\r\napt -y --no-install-recommends install ca-certificates bzip2 wget tar curl jq\r\napt -q clean all\r\n\r\n#Create needed directories\r\nmkdir -p \/mnt\/server\/TeamSpeak3-Client-linux_amd64\/plugins\r\nmkdir \/mnt\/server\/youtube-dlp\r\n\r\ncd \/mnt\/server\r\n\r\n#Download Sinusbot\r\n\r\nif [ \"${PRE_RELEASE}\" == \"1\" ]; then\r\necho \"pre\"\r\nDOWNLOAD_URL=$(curl -sSL https:\/\/forum.sinusbot.com\/threads\/upcoming-changes.8659\/ | grep -Eo \"(http|https):\/\/[a-zA-Z0-9.\/?=_-]*\" | sort -u | grep pre\/)\r\nwget -qO - ${DOWNLOAD_URL} | tar xj    \r\nelse\r\necho \"release\"\r\nwget -qO - https:\/\/www.sinusbot.com\/dl\/sinusbot.current.tar.bz2 | tar xj\r\nfi\r\n\r\n#Download Latest TeamSpeak Client\r\nTS_VERSION=$(curl https:\/\/teamspeak.com\/versions\/client.json | jq -r '.linux.x86_64.version')\r\nTS_DL_LINK=$(curl https:\/\/teamspeak.com\/versions\/client.json | jq -r '.linux.x86_64.mirrors.\"teamspeak.com\"')\r\n\r\necho -e \"downloading teamspeak version ${TS_VERSION}\"\r\necho -e \"running 'wget ${TS_DL_LINK}'\"\r\n\r\nwget ${TS_DL_LINK}\r\n\r\n# Install TeamSpeak Client\r\nchmod 0755 TeamSpeak3-Client-linux_amd64*.run\r\n.\/TeamSpeak3-Client-linux_amd64*.run --tar xfv -C TeamSpeak3-Client-linux_amd64\r\n\r\n## Cleaning up \r\n\r\nrm TeamSpeak3-Client-linux_amd64*.run\r\n# Remove glx-integration lib\r\nrm TeamSpeak3-Client-linux_amd64\/xcbglintegrations\/libqxcb-glx-integration.so\r\n\r\n#Install Sinusbot\r\nchmod +x sinusbot\r\ncp config.ini.dist config.ini\r\nsed -i \"s|^TS3Path.*|TS3Path = \\\"\/home\/container\/TeamSpeak3-Client-linux_amd64\/ts3client_linux_amd64\\\"|g\" config.ini\r\necho 'YoutubeDLPath = \"\/home\/container\/youtube-dlp\/youtube-dlp\"' >> config.ini\r\n\r\n#Install Sinusbot plugin\r\ncp plugin\/libsoundbot_plugin.so TeamSpeak3-Client-linux_amd64\/plugins\r\n\r\n#Download youtube-dlp\r\ncd \/mnt\/server\/youtube-dlp\r\nwget https:\/\/github.com\/yt-dlp\/yt-dlp\/releases\/latest\/download\/yt-dlp -O youtube-dlp\r\nchmod a+rx youtube-dlp\r\n\r\necho \"-----------------------------------------\"\r\necho \"Installation completed...\"\r\necho \"-----------------------------------------\"",
+            "script": "#!\/bin\/bash\r\n# Sinusbot Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\napt -y update\r\napt -y --no-install-recommends install ca-certificates bzip2 wget tar curl jq\r\napt -q clean all\r\n\r\n#Create needed directories\r\nmkdir -p \/mnt\/server\/TeamSpeak3-Client-linux_amd64\/plugins\r\nmkdir \/mnt\/server\/youtube-dlp\r\n\r\ncd \/mnt\/server\r\n\r\n#Download Sinusbot\r\nwget -qO - https:\/\/www.sinusbot.com\/dl\/sinusbot.current.tar.bz2 | tar xj\r\n\r\n\r\n#Download Latest TeamSpeak Client\r\n#TS_VERSION=$(curl https:\/\/teamspeak.com\/versions\/client.json | jq -r '.linux.x86_64.version')\r\n#TS_DL_LINK=$(curl https:\/\/teamspeak.com\/versions\/client.json | jq -r '.linux.x86_64.mirrors.\"teamspeak.com\"')\r\n\r\n# Sinusbot is not yet updated...\r\nTS_VERSION=3.5.6\r\nTS_DL_LINK=https:\/\/files.teamspeak-services.com\/releases\/client\/3.5.6\/TeamSpeak3-Client-linux_amd64-3.5.6.run\r\n\r\necho -e \"downloading teamspeak version ${TS_VERSION}\"\r\necho -e \"running 'wget ${TS_DL_LINK}'\"\r\n\r\nwget ${TS_DL_LINK}\r\n\r\n# Install TeamSpeak Client\r\nchmod 0755 TeamSpeak3-Client-linux_amd64*.run\r\n.\/TeamSpeak3-Client-linux_amd64*.run --tar xfv -C TeamSpeak3-Client-linux_amd64\r\n\r\n## Cleaning up \r\n\r\nrm TeamSpeak3-Client-linux_amd64*.run\r\n# Remove glx-integration lib\r\nrm TeamSpeak3-Client-linux_amd64\/xcbglintegrations\/libqxcb-glx-integration.so\r\n\r\n#Install Sinusbot\r\nchmod +x sinusbot\r\ncp config.ini.dist config.ini\r\nsed -i \"s|^TS3Path.*|TS3Path = \\\"\/home\/container\/TeamSpeak3-Client-linux_amd64\/ts3client_linux_amd64\\\"|g\" config.ini\r\necho 'YoutubeDLPath = \"\/home\/container\/youtube-dlp\/youtube-dlp\"' >> config.ini\r\n\r\n#Install Sinusbot plugin\r\ncp plugin\/libsoundbot_plugin.so TeamSpeak3-Client-linux_amd64\/plugins\r\n\r\n#Download youtube-dlp\r\ncd \/mnt\/server\/youtube-dlp\r\nwget https:\/\/github.com\/yt-dlp\/yt-dlp\/releases\/latest\/download\/yt-dlp -O youtube-dlp\r\nchmod a+rx youtube-dlp\r\n\r\necho \"-----------------------------------------\"\r\necho \"Installation completed...\"\r\necho \"-----------------------------------------\"",
             "container": "debian:bullseye-slim",
             "entrypoint": "bash"
         }
@@ -36,16 +36,6 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|string|max:20",
-            "field_type": "text"
-        },
-        {
-            "name": "Pre release",
-            "description": "Download the pre-release version?",
-            "env_variable": "PRE_RELEASE",
-            "default_value": "0",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": "required|boolean",
             "field_type": "text"
         }
     ]


### PR DESCRIPTION
# Description

- remove the pre-release as it is not more used
- hard set the TS3 version to 3.5.6 because sinusbot is not yet updated for next releases, files are still download from there offical site here: https://files.teamspeak-services.com/releases/client/3.5.6/

```bash

#Download Latest TeamSpeak Client
#TS_VERSION=$(curl https://teamspeak.com/versions/client.json | jq -r '.linux.x86_64.version')
#TS_DL_LINK=$(curl https://teamspeak.com/versions/client.json | jq -r '.linux.x86_64.mirrors."teamspeak.com"')

# Sinusbot is not yet updated...
TS_VERSION=3.5.6
TS_DL_LINK=https://files.teamspeak-services.com/releases/client/3.5.6/TeamSpeak3-Client-linux_amd64-3.5.6.run

echo -e "downloading teamspeak version ${TS_VERSION}"
echo -e "running 'wget ${TS_DL_LINK}'"
```

this is what I have done to the install script

closes #2375 

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [x] You verify that the start command applied does not use a shell script
  * [ ] If some script is needed then it is part of a current yolk or a PR to add one
* [x] The egg was exported from the panel

<!-- You can erase the new egg submission template if you're not adding a completely new egg -->
