### PR TITLE
Updated Java Versions for PhantomBot

### DIFF
--- a/bots/twitch/phantombot/egg-phantom-bot.json
+++ b/bots/twitch/phantombot/egg-phantom-bot.json
@@ -4,13 +4,14 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2022-10-02T18:28:42+02:00",
+    "exported_at": "2023-09-02T23:24:58+00:00",
     "name": "PhantomBot",
     "author": "mail@wuffy.eu",
     "description": "PhantomBot is an actively developed open source interactive Twitch bot with a vibrant community that provides entertainment and moderation for your channel, allowing you to focus on what matters the most to you - your game and your viewers.",
     "features": null,
     "docker_images": {
-        "ghcr.io\/parkervcp\/yolks:java_11": "ghcr.io\/parkervcp\/yolks:java_11"
+        "Java 16 [DEPRECATED]": "ghcr.io\/parkervcp\/yolks:java_16",
+        "Java 19": "ghcr.io\/parkervcp\/yolks:java_19"
     },
     "file_denylist": [],
     "startup": "java --add-opens java.base\/java.lang=ALL-UNNAMED -Djava.security.policy=config\/security -Dinteractive -Xms1m -Dfile.encoding=UTF-8 -jar PhantomBot.jar",
@@ -30,12 +31,12 @@
     "variables": [
         {
             "name": "Version",
-            "description": "latest = Latest Stable\r\nmaster = latest Github",
+            "description": "latest = Latest Stable\r\nmaster = latest Github\r\n3.9.0.7 = Latest known working with Java 16",
             "env_variable": "RELEASE_VERSION",
             "default_value": "latest",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string|max:9",
+            "rules": "required|string|in:latest,master,3.9.0.7",
             "field_type": "text"
         },
         {

--- a/bots/twitch/phantombot/egg-phantom-bot.json
+++ b/bots/twitch/phantombot/egg-phantom-bot.json
@@ -36,7 +36,7 @@
             "default_value": "latest",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string|in:latest,master,3.9.0.7",
+            "rules": "required|string|max:9",
             "field_type": "text"
         },
         {


### PR DESCRIPTION
# Description

Updated Java versions as Java 11 has been deprecated for a while.
Added Java 16 as the last version known working up to Phantombot v3.9.0.7
Added current Java versions for current versions of Phantombot

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you tested and reviewed your changes with confidence that everything works?
* [X] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [X] You verify that the start command applied does not use a shell script
  * [X] If some script is needed then it is part of a current yolk or a PR to add one
* [X] The egg was exported from the panel