### PR TITLE
Specifies DB path in env variables

### DIFF
--- a/software/uptime-kuma/egg-uptime-kuma.json
+++ b/software/uptime-kuma/egg-uptime-kuma.json
@@ -77,6 +77,16 @@
             "user_editable": false,
             "rules": "nullable|string",
             "field_type": "text"
+        },
+        {
+            "name": "Data Directory",
+            "description": "The directory that Uptime Kuma will look for the kuma.db in.",
+            "env_variable": "DATA_DIR",
+            "default_value": ".\/db\/",
+            "user_viewable": false,
+            "user_editable": false,
+            "rules": "required|string|max:20",
+            "field_type": "text"
         }
     ]
 }

--- a/software/uptime-kuma/egg-uptime-kuma.json
+++ b/software/uptime-kuma/egg-uptime-kuma.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2023-09-25T18:09:50+02:00",
+    "exported_at": "2023-10-01T00:09:31-04:00",
     "name": "Uptime Kuma",
     "author": "info@goover.de",
     "description": "Uptime Kuma is an easy-to-use self-hosted monitoring tool.",


### PR DESCRIPTION
# Description
Fixes an issue where Uptime Kuma wouldn't be able to find the db correctly causing it to enter an infinite setup loop. By Specifying the correct directory an environmental variable it works correctly.
<!-- Please explain what is being changed or added as a short overview for this PR. Also, link existing relevant issues if they exist with resolves # -->

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you tested and reviewed your changes with confidence that everything works?
* [X] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [X] You verify that the start command applied does not use a shell script
  * [X] If some script is needed then it is part of a current yolk or a PR to add one
* [X] The egg was exported from the panel