### PR TITLE
Fixes Zombied Server on Shutdown/Restart [ARK: Survival Ascended]

### DIFF
--- a/game_eggs/steamcmd_servers/ark_survival_ascended/README.md
+++ b/game_eggs/steamcmd_servers/ark_survival_ascended/README.md
@@ -5,14 +5,35 @@ ARK is reimagined from the ground-up into the next-generation of video game tech
 
 ## Troubleshooting
 
-Crash logs are available in the Files `ShooterGame/Saved/Crashes/UECC-Windows-*/CrashContext.runtime-xml`
+1) Try starting the server with no mods on a fresh install.
+
+2) If there are crash logs, they will be available in the Files at `ShooterGame/Saved/Crashes/UECC-Windows-*/CrashContext.runtime-xml`
+
+### Crash Identifiers
+
+Crashes will either stop the server or display 0-5% CPU usage.
+The number is in reference to RAM/Memory usage.
+
+1) Server crashing around 500MB is probably either a config issue or a corrupted install.
+
+2) Server crashing around 750MB is probably commandline issue.
+
+3) Server crashing around 1GB is probably either a MOD conflict or corrupted SavedArks files.
+
+
+## Known Issues
+
+1) ARK: Survival Ascended, currently, does not support more than one server per IP. 
+These are Windows Server files running on a Linux container; so, we believe this is the issue.
+
+2) ARK's wiki heavily reference A:SE and not all features are available in A:SA.
 
 
 ## Recommended server settings
 
 ### Minimum RAM
 
-This server requires about 8-10GB of RAM to run with no players on a default map.
+This server requires about 11GB of RAM to run with no players on a default map.
 
 See the following - <https://ark.wiki.gg/wiki/Dedicated_server_setup#RAM>
 

--- a/game_eggs/steamcmd_servers/ark_survival_ascended/egg-ark--survival-ascended.json
+++ b/game_eggs/steamcmd_servers/ark_survival_ascended/egg-ark--survival-ascended.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2023-10-30T13:56:57-04:00",
+    "exported_at": "2023-11-01T12:21:14-04:00",
     "name": "ARK: Survival Ascended",
     "author": "blood@darkartsgaming.com",
     "description": "ARK is reimagined from the ground-up into the next-generation of video game technology with Unreal Engine 5! Form a tribe, tame & breed hundreds of unique dinosaurs and primeval creatures, explore, craft, build, and fight your way to the top of the food-chain. Your new world awaits!",
@@ -15,7 +15,7 @@
         "Proton": "ghcr.io\/parkervcp\/steamcmd:proton"
     },
     "file_denylist": [],
-    "startup": "rmv() { echo \"stopping server\"; rcon -t rcon -a 127.0.0.1:${RCON_PORT} -p ${ARK_ADMIN_PASSWORD} DoExit && wait ${ARK_PID}; echo \"Server Closed\"; exit; }; trap rmv 15 2; proton run .\/ShooterGame\/Binaries\/Win64\/ArkAscendedServer.exe {{SERVER_MAP}}?listen?MaxPlayers={{MAX_PLAYERS}}?SessionName=\"{{SESSION_NAME}}\"?Port={{SERVER_PORT}}?QueryPort={{QUERY_PORT}}?RCONPort={{RCON_PORT}}?RCONEnabled=True$( [  \"$SERVER_PVE\" == \"0\" ] || printf %s '?ServerPVE=True' )?ServerPassword=\"{{SERVER_PASSWORD}}\"{{ARGS_PARAMS}}?ServerAdminPassword=\"{{ARK_ADMIN_PASSWORD}}\" -WinLiveMaxPlayers={{MAX_PLAYERS}} -oldconsole -servergamelog$( [ -z \"$MOD_IDS\" ] || printf %s ' -mods=' $MOD_IDS )$( [ \"$BATTLE_EYE\" == \"1\" ] || printf %s ' -NoBattlEye' ) {{ARGS_FLAGS}} & ARK_PID=$! ; tail -c0 -F .\/ShooterGame\/Saved\/Logs\/ShooterGame.log --pid=$ARK_PID & until echo \"waiting for rcon connection...\"; (rcon -t rcon -a 127.0.0.1:${RCON_PORT} -p ${ARK_ADMIN_PASSWORD})<&0 & wait $!; do sleep 5; done",
+    "startup": "rmv() { echo \"stopping server\"; rcon -t rcon -a 127.0.0.1:${RCON_PORT} -p ${ARK_ADMIN_PASSWORD} KeepAlive && rcon -t rcon -a 127.0.0.1:${RCON_PORT} -p ${ARK_ADMIN_PASSWORD} DoExit && wait ${ARK_PID}; echo \"Server Closed\"; exit; }; trap rmv 15 2; proton run .\/ShooterGame\/Binaries\/Win64\/ArkAscendedServer.exe {{SERVER_MAP}}?listen?MaxPlayers={{MAX_PLAYERS}}?SessionName=\"{{SESSION_NAME}}\"?Port={{SERVER_PORT}}?QueryPort={{QUERY_PORT}}?RCONPort={{RCON_PORT}}?RCONEnabled=True$( [  \"$SERVER_PVE\" == \"0\" ] || printf %s '?ServerPVE=True' )?ServerPassword=\"{{SERVER_PASSWORD}}\"{{ARGS_PARAMS}}?ServerAdminPassword=\"{{ARK_ADMIN_PASSWORD}}\" -WinLiveMaxPlayers={{MAX_PLAYERS}} -oldconsole -servergamelog$( [ -z \"$MOD_IDS\" ] || printf %s ' -mods=' $MOD_IDS )$( [ \"$BATTLE_EYE\" == \"1\" ] || printf %s ' -NoBattlEye' ) {{ARGS_FLAGS}} & ARK_PID=$! ; tail -c0 -F .\/ShooterGame\/Saved\/Logs\/ShooterGame.log --pid=$ARK_PID & until echo \"waiting for rcon connection...\"; (rcon -t rcon -a 127.0.0.1:${RCON_PORT} -p ${ARK_ADMIN_PASSWORD})<&0 & wait $!; do sleep 5; done",
     "config": {
         "files": "{\r\n    \"ShooterGame\/Saved\/Config\/WindowsServer\/GameUserSettings.ini\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"MaxPlayers=\": \"MaxPlayers={{server.build.env.MAX_PLAYERS}}\",\r\n            \"ServerAdminPassword=\": \"ServerAdminPassword={{server.build.env.ARK_ADMIN_PASSWORD}}\"\r\n        }\r\n    }\r\n}",
         "startup": "{\r\n    \"done\": \"Waiting commands for 127.0.0.1:\"\r\n}",


### PR DESCRIPTION
# Description

- `KeepAlive` has been added at shutdown due to extended up-times causing the next rcon command (`DoExit`) in-console to timeout; resulting in zombied servers.
- Added some very helpful troubleshooting tips to the README
- Added Known Issues to the README
- Bumped up the RAM requirements in the README

Reason for `KeepAlive` over `SaveWorld` is because `DoExit` does a `SaveWorld` and `KeepAlive` is not a command that's processed by the server. However, using `KeepAlive` will simply ping/pong the connection without causing an additional load as apposed to doing two `SaveWorld`(s) at the same time. Also, there is a slight chance that RCON will receive commands before the server is completely ready to do a proper `SaveWorld` where a `DoExit` will identify this properly and shutdown the server gracefully over a potential corrupted `SaveWorld`.

## Checklist for all submissions

* [x] You verify that the start command applied does not use a shell script
  * [ ] If some script is needed then it is part of a current yolk or a PR to add one
* [x] The egg was exported from the panel