### PR TITLE
Update Hogwarp [Plugin Fix]

### DIFF
--- a/game_eggs/hogwarp/README.md
+++ b/game_eggs/hogwarp/README.md
@@ -5,8 +5,6 @@ HogWarp is a Work In Progress mod that adds Multiplayer functionality to Hogwart
 This Mod requires a API key only obtainable through their Discord, see the Startup Variable **API KEY** for more info.
 - Some features of the mod (Public servers / higher player counts) require a Patreon level. See their Patreon here: https://www.patreon.com/tiltedphoques
 
-Plugins as of now **do not work** as Wine and Winetricks will break the DLL it runs off of. This will likely stay the case until a full Linux release
-
 ## Server Port
 | Port    | default |
 |---------|---------|

--- a/game_eggs/hogwarp/egg-hogwarp.json
+++ b/game_eggs/hogwarp/egg-hogwarp.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2023-11-14T12:12:21-05:00",
+    "exported_at": "2023-12-30T05:00:38-05:00",
     "name": "Hogwarp",
     "author": "imkringle@proton.me",
     "description": "A Pterodactyl egg for the Hogwarts Legacy mod Hogwarp - For more info see their Nexus: https:\/\/www.nexusmods.com\/hogwartslegacy\/mods\/1378",
@@ -13,10 +13,10 @@
         "ghcr.io\/parkervcp\/yolks:wine_latest": "ghcr.io\/parkervcp\/yolks:wine_latest"
     },
     "file_denylist": [],
-    "startup": "wine HogWarpServer.exe",
+    "startup": "export WINEDLLOVERRIDES=\"mscoree=n,b;mshtml=n,b\"; wine HogWarpServer.exe",
     "config": {
         "files": "{\r\n    \"config.json\": {\r\n        \"parser\": \"json\",\r\n        \"find\": {\r\n            \"ApiKey\": \"{{env.API_KEY}}\",\r\n            \"Name\": \"{{env.SERV_NAME}}\",\r\n            \"Port\": \"{{server.build.default.port}}\",\r\n            \"Description\": \"{{env.SERV_DESC}}\",\r\n            \"MaxPlayer\": \"{{env.MAX_PLAYERS}}\",\r\n            \"IconUrl\": \"{{env.SERV_ICON}}\"\r\n        }\r\n    }\r\n}",
-        "startup": "{\r\n    \"done\": \" [HogWarpServer] \"\r\n}",
+        "startup": "{\r\n    \"done\": \"Server started on port \"\r\n}",
         "logs": "{}",
         "stop": "^^C"
     },
@@ -32,7 +32,7 @@
             "name": "Wine Tricks",
             "description": "",
             "env_variable": "WINETRICKS_RUN",
-            "default_value": "",
+            "default_value": "dotnet7",
             "user_viewable": false,
             "user_editable": false,
             "rules": "nullable|string",


### PR DESCRIPTION
# Description

This update fixes the Nethost error on Startup and allows Plugins to load as intended.

- Cleaned up the Startup to a true successful startup (now set to opening on port: x)
- added Winetricks dotnet7 variable per Hogwarp requirements after a fix to their git [Here](https://github.com/Winetricks/winetricks/issues/2163#event-11359705113)
- added WINEDLLOVERRIDES to startup rather than variable


## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [x] You verify that the start command applied does not use a shell script
  * [ ] If some script is needed then it is part of a current yolk or a PR to add one
* [x] The egg was exported from the panel