### PR TITLE
Hogwarp (Again. Sorry lol)

### DIFF
--- a/game_eggs/hogwarp/egg-hogwarp.json
+++ b/game_eggs/hogwarp/egg-hogwarp.json
@@ -4,13 +4,13 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2023-11-14T12:12:21-05:00",
+    "exported_at": "2023-12-30T14:42:14-05:00",
     "name": "Hogwarp",
     "author": "imkringle@proton.me",
     "description": "A Pterodactyl egg for the Hogwarts Legacy mod Hogwarp - For more info see their Nexus: https:\/\/www.nexusmods.com\/hogwartslegacy\/mods\/1378",
     "features": null,
     "docker_images": {
-        "ghcr.io\/parkervcp\/yolks:wine_latest": "ghcr.io\/parkervcp\/yolks:wine_latest"
+        "ghcr.io\/parkervcp\/yolks:wine_staging": "ghcr.io\/parkervcp\/yolks:wine_staging"
     },
     "file_denylist": [],
     "startup": "wine HogWarpServer.exe",


### PR DESCRIPTION
# Description

Changed Wine_Latest to Wine_staging, as Wine_latest allows .Net and plugins to load; it causes an Overflow exception breaking connectivity if a plugin is used - hidden by WINEDEBUG

Wine_staging / devel do not have this issue

I made an uh-oh with pushing the first one. I promise last one xD

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [x] You verify that the start command applied does not use a shell script
  * [ ] If some script is needed then it is part of a current yolk or a PR to add one
* [x] The egg was exported from the panel
