### PR TITLE
Project Zomboid: tmpfs limit

### DIFF
--- a/game_eggs/steamcmd_servers/project_zomboid/README.md
+++ b/game_eggs/steamcmd_servers/project_zomboid/README.md
@@ -4,8 +4,9 @@ Project Zomboid is the ultimate in zombie survival. Alone or in MP: you loot, bu
 
 ## Configuration
 
-Project Zomboid creates Backup on Server Start by copying its SaveData into Temp and then zipping it up, after a few days these files are so large that your Server will fail on Startup with Error: `java.util.concurrent.ExecutionException: java.io.IOException: No space left on device.
-`. Either disable Backups in the Project Zomboid Server Settings via `BackupsOnStart=false` or increase the `tmpfs_size` in your wings-docker configuration.
+Project Zomboid creates Backup on Server Start by copying its SaveData into Temp and then zipping it up, after a few days these files are so large that your Server will fail on Startup with Error: `java.util.concurrent.ExecutionException: java.io.IOException: No space left on device`. 
+
+Either disable Backups in the Project Zomboid Server Settings via `BackupsOnStart=false` or increase the `tmpfs_size` in your wings config.yml configuration file.
 
 ## Server Ports
 

--- a/game_eggs/steamcmd_servers/project_zomboid/README.md
+++ b/game_eggs/steamcmd_servers/project_zomboid/README.md
@@ -2,6 +2,11 @@
 
 Project Zomboid is the ultimate in zombie survival. Alone or in MP: you loot, build, craft, fight, farm and fish in a struggle to survive. A hardcore RPG skillset, a vast map, a massively customisable sandbox and a cute tutorial raccoon await the unwary. So how will you die?
 
+## Configuration
+
+Project Zomboid creates Backup on Server Start by copying its SaveData into Temp and then zipping it up, after a few days these files are so large that your Server will fail on Startup with Error: `java.util.concurrent.ExecutionException: java.io.IOException: No space left on device.
+`. Either disable Backups in the Project Zomboid Server Settings via `BackupsOnStart=false` or increase the `tmpfs_size` in your wings-docker configuration.
+
 ## Server Ports
 
 Project Zomboid requires one port for game data and one port for Steam.


### PR DESCRIPTION
# Description

Project Zomboid creates Backup on Server Start by copying its SaveData into Temp and then zipping it up, after a few days these files are so large that your Server will fail on Startup.

## Checklist for all submissions

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you tested and reviewed your changes with confidence that everything works?
* [X] Did you branch your changes and PR from that branch and not from your master branch?
