### PR TITLE
feat(generic): expose python 3.12

### DIFF
--- a/generic/python/egg-python-generic.json
+++ b/generic/python/egg-python-generic.json
@@ -10,6 +10,7 @@
     "description": "A Generic Python Egg for Pterodactyl\r\n\r\nTested with: https:\/\/github.com\/Ispira\/pixel-bot",
     "features": null,
     "docker_images": {
+        "Python 3.12": "ghcr.io\/parkervcp\/yolks:python_3.12",
         "Python 3.11": "ghcr.io\/parkervcp\/yolks:python_3.11",
         "Python 3.10": "ghcr.io\/parkervcp\/yolks:python_3.10",
         "Python 3.9": "ghcr.io\/parkervcp\/yolks:python_3.9",


### PR DESCRIPTION
# Description

Looks like you already made a upstream change to support 3.12 so I am just exposing it here.

Would be really cool to figure out how we can support https://github.com/pdm-project/pdm and https://python-poetry.org/ to install python packages through them.

Cheers