### PR TITLE
Replace Oxide with Modding Framework

### DIFF
--- a/game_eggs/steamcmd_servers/rust/rust_autowipe/egg-rust-autowipe.json
+++ b/game_eggs/steamcmd_servers/rust/rust_autowipe/egg-rust-autowipe.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2023-06-17T16:29:22+03:00",
+    "exported_at": "2024-02-02T22:41:26+02:00",
     "name": "Rust Autowipe",
     "author": "support@pterodactyl.io",
     "description": "The only aim in Rust is to survive. To do this you will need to overcome struggles such as hunger, thirst and cold. Build a fire. Build a shelter. Kill animals for meat. Protect yourself from other players, and kill them for meat. Create alliances with other players and form a town. Do whatever it takes to survive.",
@@ -61,10 +61,10 @@
             "field_type": "text"
         },
         {
-            "name": "OxideMod",
-            "description": "Set whether you want the server to use and auto update OxideMod or not. Valid options are \"1\" for true and \"0\" for false.",
-            "env_variable": "OXIDE",
-            "default_value": "0",
+            "name": "Modding Framework",
+            "description": "The modding framework to be used: carbon, oxide, vanilla.\r\nDefaults to \"vanilla\" for a non-modded server installation.",
+            "env_variable": "FRAMEWORK",
+            "default_value": "vanilla",
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|boolean",


### PR DESCRIPTION
# Description

Added Carbon support, thus removing Oxide variable and replacing it with newer modding framework variable.

## Checklist for all submissions

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?

* [x] You verify that the start command applied does not use a shell script
  * [ ] If some script is needed then it is part of a current yolk or a PR to add one
* [x] The egg was exported from the panel