### PR TITLE
fix the rust autowipe egg

### DIFF
--- a/game_eggs/steamcmd_servers/rust/rust_autowipe/egg-rust-autowipe.json
+++ b/game_eggs/steamcmd_servers/rust/rust_autowipe/egg-rust-autowipe.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2024-02-02T22:41:26+02:00",
+    "exported_at": "2024-02-02T22:25:49-05:00",
     "name": "Rust Autowipe",
     "author": "support@pterodactyl.io",
     "description": "The only aim in Rust is to survive. To do this you will need to overcome struggles such as hunger, thirst and cold. Build a fire. Build a shelter. Kill animals for meat. Protect yourself from other players, and kill them for meat. Create alliances with other players and form a town. Do whatever it takes to survive.",
@@ -58,16 +58,6 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|string|max:40",
-            "field_type": "text"
-        },
-        {
-            "name": "Modding Framework",
-            "description": "The modding framework to be used: carbon, oxide, vanilla.\r\nDefaults to \"vanilla\" for a non-modded server installation.",
-            "env_variable": "FRAMEWORK",
-            "default_value": "vanilla",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": "required|boolean",
             "field_type": "text"
         },
         {
@@ -218,6 +208,16 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "nullable|url",
+            "field_type": "text"
+        },
+        {
+            "name": "Modding Framework",
+            "description": "The modding framework to be used: carbon, oxide, vanilla.\r\nDefaults to \"vanilla\" for a non-modded server installation.",
+            "env_variable": "FRAMEWORK",
+            "default_value": "vanilla",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string|in:vanilla,carbon,oxide",
             "field_type": "text"
         }
     ]


### PR DESCRIPTION
changes the framework variable to accept vanilla, carbon, and oxide. resolves #2726

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:


* [x] You verify that the start command applied does not use a shell script
  * [x] If some script is needed then it is part of a current yolk or a PR to add one
* [x] The egg was exported from the panel
