### PR TITLE
Add .NET 8 Docker Image

### DIFF
--- a/generic/c#/egg-generic-c.json
+++ b/generic/c#/egg-generic-c.json
@@ -10,6 +10,7 @@
     "description": "A generic C# (dotnet) egg that runs your C# project.",
     "features": null,
     "docker_images": {
+        "Dotnet_8": "ghcr.io\/parkervcp\/yolks:dotnet_8",
         "Dotnet_7": "ghcr.io\/parkervcp\/yolks:dotnet_7",
         "Dotnet_6": "ghcr.io\/parkervcp\/yolks:dotnet_6",
         "Dotnet_5": "ghcr.io\/parkervcp\/yolks:dotnet_5",

--- a/generic/c#/egg-generic-c.json
+++ b/generic/c#/egg-generic-c.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2023-07-02T19:22:35+02:00",
+    "exported_at": "2024-03-24T14:29:09+01:00",
     "name": "Generic C#",
     "author": "josdekurk@gmail.com",
     "description": "A generic C# (dotnet) egg that runs your C# project.",


### PR DESCRIPTION
# Description

The docker image for .NET 8 has been added to the already-existing generic-c egg.

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [?] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?: I'm not super familiar with GitHub and pull requests, so I'm not fully sure what this means.

<!-- If this is an egg update fill these out -->

* [x] You verify that the start command applied does not use a shell script
  * [x] If some script is needed then it is part of a current yolk or a PR to add one
* [x] The egg was exported from the panel