### PR TITLE
Add 3.3/stable yolks and git reset options to dart egg

### DIFF
--- a/generic/dart/egg-dart-generic.json
+++ b/generic/dart/egg-dart-generic.json
@@ -10,12 +10,14 @@
     "description": "A generic dart CLI egg.\r\n\r\nThis will clone a dart CLI application. it defaults to master if no branch is specified.\r\n\r\nInstalls the pubspec.yaml packages on run. If you set user_upload then I assume you know what you are doing.",
     "features": null,
     "docker_images": {
+        "Dart_stable": "ghcr.io\/parkervcp\/yolks:dart_stable",
+        "Dart_3.3": "ghcr.io\/parkervcp\/yolks:dart_3.3",
         "Dart_2.19": "ghcr.io\/parkervcp\/yolks:dart_2.19",
         "Dart_2.18": "ghcr.io\/parkervcp\/yolks:dart_2.18",
         "Dart_2.17": "ghcr.io\/parkervcp\/yolks:dart_2.17"
     },
     "file_denylist": [],
-    "startup": "if [[ -d .git ]] && [[ {{AUTO_UPDATE}} == \"1\" ]]; then git pull; fi; dart pub get; dart run",
+    "startup": "if [[ -d .git ]] && [[ {{AUTO_UPDATE}} == \"1\" ]]; then git pull; fi; if [[ -d .git ]] && [[ {{AUTO_RESET}} == \"1\" ]]; then git reset --hard; fi; dart pub get; dart run",
     "config": {
         "files": "{}",
         "startup": "{\r\n    \"done\": \"change this part\"\r\n}",
@@ -64,6 +66,16 @@
             "name": "Auto Update",
             "description": "Pull the latest files on startup when using a GitHub repo.",
             "env_variable": "AUTO_UPDATE",
+            "default_value": "0",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|boolean",
+            "field_type": "text"
+        },
+        {
+            "name": "Auto Reset",
+            "description": "Git reset the latest files on startup when using a GitHub repo.",
+            "env_variable": "AUTO_RESET",
             "default_value": "0",
             "user_viewable": true,
             "user_editable": true,

--- a/generic/dart/egg-dart-generic.json
+++ b/generic/dart/egg-dart-generic.json
@@ -4,14 +4,14 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2023-02-24T17:58:34+01:00",
+    "exported_at": "2024-04-01T13:16:45-07:00",
     "name": "dart generic",
     "author": "alden@knoban.com",
     "description": "A generic dart CLI egg.\r\n\r\nThis will clone a dart CLI application. it defaults to master if no branch is specified.\r\n\r\nInstalls the pubspec.yaml packages on run. If you set user_upload then I assume you know what you are doing.",
     "features": null,
     "docker_images": {
-        "Dart_stable": "ghcr.io\/parkervcp\/yolks:dart_stable",
-        "Dart_3.3": "ghcr.io\/parkervcp\/yolks:dart_3.3",
+        "Dart_stable": "ghcr.io\/knoapp\/yolks:dart_stable",
+        "Dart_3.3": "ghcr.io\/knoapp\/yolks:dart_3.3",
         "Dart_2.19": "ghcr.io\/parkervcp\/yolks:dart_2.19",
         "Dart_2.18": "ghcr.io\/parkervcp\/yolks:dart_2.18",
         "Dart_2.17": "ghcr.io\/parkervcp\/yolks:dart_2.17"

--- a/generic/dart/egg-dart-generic.json
+++ b/generic/dart/egg-dart-generic.json
@@ -17,7 +17,7 @@
         "Dart_2.17": "ghcr.io\/parkervcp\/yolks:dart_2.17"
     },
     "file_denylist": [],
-    "startup": "if [[ -d .git ]] && [[ {{AUTO_UPDATE}} == \"1\" ]]; then git pull; fi; if [[ -d .git ]] && [[ {{AUTO_RESET}} == \"1\" ]]; then git reset --hard; fi; dart pub get; dart run",
+    "startup": "if [[ -d .git ]] && [[ {{AUTO_RESET}} == \"1\" ]]; then git reset --hard; fi; if [[ -d .git ]] && [[ {{AUTO_UPDATE}} == \"1\" ]]; then git pull; fi; dart pub get; dart run",
     "config": {
         "files": "{}",
         "startup": "{\r\n    \"done\": \"change this part\"\r\n}",
@@ -74,7 +74,7 @@
         },
         {
             "name": "Auto Reset",
-            "description": "Git reset the latest files on startup when using a GitHub repo.",
+            "description": "Hard reset the latest files on startup when using a GitHub repo.",
             "env_variable": "AUTO_RESET",
             "default_value": "0",
             "user_viewable": true,


### PR DESCRIPTION
# Description

The yolks introduced in https://github.com/parkervcp/yolks/pull/229 are added to the Dart generic egg. Additionally, a git hard reset option has been created.

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [x] You verify that the start command applied does not use a shell script
  * [x] If some script is needed then it is part of a current yolk or a PR to add one
* [x] The egg was exported from the panel