### PR TITLE
SE/move to mono insteed dotnet

### DIFF
--- a/game_eggs/steamcmd_servers/space_engineers/default/egg-space-engineers.json
+++ b/game_eggs/steamcmd_servers/space_engineers/default/egg-space-engineers.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2024-03-09T11:25:43+01:00",
+    "exported_at": "2024-04-03T18:32:09+02:00",
     "name": "Space Engineers",
     "author": "eggs@goover.dev",
     "description": "Space Engineers is a voxel-based sandbox game set in space and on planets.",
@@ -194,7 +194,7 @@
             "name": "WINETRICKS_RUN",
             "description": "",
             "env_variable": "WINETRICKS_RUN",
-            "default_value": "vcrun2022 dotnet48 corefonts",
+            "default_value": "win11 vcrun2022 mono corefonts",
             "user_viewable": false,
             "user_editable": false,
             "rules": "required|string",


### PR DESCRIPTION
# Description

Move to mono insteed dotnet, because server crash with dotnet. Wine

mb wait for this PR: https://github.com/parkervcp/yolks/pull/231
i used mono 9.0.0

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [ ] You verify that the start command applied does not use a shell script
  * [ ] If some script is needed then it is part of a current yolk or a PR to add one
* [x] The egg was exported from the panel

<!-- You can erase the new egg submission template if you're not adding a completely new egg -->