### PR TITLE
Fix Stationeers eggs worldnames

### DIFF
--- a/game_eggs/steamcmd_servers/stationeers/stationeers_bepinex/egg-stationeers--bep-in-ex.json
+++ b/game_eggs/steamcmd_servers/stationeers/stationeers_bepinex/egg-stationeers--bep-in-ex.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2023-10-28T19:39:03+02:00",
+    "exported_at": "2024-04-05T01:20:18+02:00",
     "name": "Stationeers (BepInEx)",
     "author": "eggs@goover.dev",
     "description": "Stationeers Server with very basic BepInEx support",
@@ -42,12 +42,12 @@
         },
         {
             "name": "World Name",
-            "description": "Available Maps: moon, mars, europa, europa2, mimas, vulcan, vulcan2, space, loulan, venus",
+            "description": "Available Maps: Moon, Mars, Europa, Europa2, Mimas, Vulcan, Vulcan2, Space, Loulan, Venus",
             "env_variable": "WORLD_NAME",
             "default_value": "moon",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "nullable|string|in:,moon,mars,europa,europa2,mimas,vulcan,vulcan2,space,loulan,venus",
+            "rules": "nullable|string|in:,Moon,Mars,Europa,Europa2,Mimas,Vulcan,Vulcan2,Space,Loulan,Venus",
             "field_type": "text"
         },
         {

--- a/game_eggs/steamcmd_servers/stationeers/stationeers_vanilla/egg-stationeers.json
+++ b/game_eggs/steamcmd_servers/stationeers/stationeers_vanilla/egg-stationeers.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2022-12-30T11:39:51+01:00",
+    "exported_at": "2024-04-05T01:19:24+02:00",
     "name": "Stationeers",
     "author": "eggs@goover.dev",
     "description": "Stationeers Server",
@@ -42,12 +42,12 @@
         },
         {
             "name": "World Name",
-            "description": "Available Maps: moon, mars, europa, europa2, mimas, vulcan, vulcan2, space, loulan, venus",
+            "description": "Available Maps: Moon, Mars, Europa, Europa2, Mimas, Vulcan, Vulcan2, Space, Loulan, Venus",
             "env_variable": "WORLD_NAME",
             "default_value": "moon",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "nullable|string|in:,moon,mars,europa,europa2,mimas,vulcan,vulcan2,space,loulan,venus",
+            "rules": "nullable|string|in:,Moon,Mars,Europa,Europa2,Mimas,Vulcan,Vulcan2,Space,Loulan,Venus",
             "field_type": "text"
         },
         {


### PR DESCRIPTION
# Description

This updates the egg to fix [#2711](https://github.com/parkervcp/eggs/issues/2711)
Stationeers Server process didn't start listening on designated ports because the worldname was written all in lowercase an the game could not find the world without reporting any errors.

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you tested and reviewed your changes with confidence that everything works?
* [X] Did you branch your changes and PR from that branch and not from your master branch?

<!-- If this is an egg update fill these out -->

* [X] You verify that the start command applied does not use a shell script
  * [X] If some script is needed then it is part of a current yolk or a PR to add one
* [X] The egg was exported from the panel