### PR TITLE
Added Java Version 11 to nano limbo egg

### DIFF
--- a/game_eggs/minecraft/java/nanolimbo/egg-nano-limbo.json
+++ b/game_eggs/minecraft/java/nanolimbo/egg-nano-limbo.json
@@ -14,7 +14,8 @@
         "pid_limit"
     ],
     "docker_images": {
-        "ghcr.io\/parkervcp\/yolks:java_8": "ghcr.io\/parkervcp\/yolks:java_8"
+        "ghcr.io\/parkervcp\/yolks:java_8": "ghcr.io\/parkervcp\/yolks:java_8",
+        "ghcr.io\/parkervcp\/yolks:java_11": "ghcr.io\/parkervcp\/yolks:java_11"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",


### PR DESCRIPTION
Added new java version (Java version 11) to the Nano Limbo Egg for Minecraft.
This Java version is required by the newest version of Nano Limbo.